### PR TITLE
Fixing missed comment in snippets

### DIFF
--- a/snippets/developer-preview-admonition.adoc
+++ b/snippets/developer-preview-admonition.adoc
@@ -1,5 +1,5 @@
 // When including this file, ensure that {FeatureName} is set immediately before the include. Otherwise it will result in an incorrect replacement.
-:FeatureName:
+// use :FeatureName:
 
 [IMPORTANT]
 ====

--- a/snippets/developer-preview.adoc
+++ b/snippets/developer-preview.adoc
@@ -1,5 +1,5 @@
 // When including this file, ensure that {FeatureName} is set immediately before the include. Otherwise it will result in an incorrect replacement.
-:FeatureName:
+// use :FeatureName:
 
 [subs="attributes+"]
 {FeatureName} is a Developer Preview feature only. Developer Preview features are not supported by Red Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features provide early access to upcoming product features in advance of their possible inclusion in a Red Hat product offering, enabling customers to test functionality and provide feedback during the development process. These features might not have any documentation, are subject to change or removal at any time, and testing is limited. Red Hat might provide ways to submit feedback on Developer Preview features without an associated SLA.

--- a/snippets/technology-preview-admonition.adoc
+++ b/snippets/technology-preview-admonition.adoc
@@ -1,6 +1,6 @@
 // When including this file, ensure that {FeatureName} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
-:FeatureName:
+// use :FeatureName:
 
 [IMPORTANT]
 ====

--- a/snippets/technology-preview.adoc
+++ b/snippets/technology-preview.adoc
@@ -1,6 +1,6 @@
 // When including this file, ensure that {FeatureName} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
-:FeatureName:
+// use :FeatureName:
 
 [subs="attributes+"]
 {FeatureName} is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.


### PR DESCRIPTION
I left the `:FeatureName:` variable uncommented in the snippets file

It should be commented out, so people can use:

```
:FeatureName: This is our new feature
include::snippets/developer-preview-admonition.adoc[]
```

