### PR TITLE
MTA-3657: Remove old disconnected installation section

### DIFF
--- a/docs/topics/mta-7-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-7-installing-web-console-on-openshift.adoc
@@ -183,6 +183,7 @@ spec:
 ** *Password*: Passw0rd!
 . When prompted, create a new password.
 
+////
 [id="installing-mta-operator-in-disconnected-environment_{context}"]
 == Installing the {ProductName} Operator in a disconnected Red Hat OpenShift environment
 
@@ -210,7 +211,7 @@ mirror:
       - name: stable
   helm: {}
 ----
-
+////
 
 [id="eviction-threshold_{context}"]
 === Eviction threshold


### PR DESCRIPTION
### JIRA

* [MTA-3657](https://issues.redhat.com/browse/MTA-3657)

This is the old disconnected install section - replaced by https://docs.redhat.com/en/documentation/migration_toolkit_for_applications/7.1/html/cli_guide/installing_and_running_the_cli#installing-mta-disconnected-environment_cli-guide


