### PR TITLE
To be merged for 7.1 WIP - MTA-4309: SVN checkout fails added to 7.1 release notes

### DIFF
--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -22,6 +22,8 @@ include::topics/making-open-source-more-inclusive.adoc[]
 
 include::topics/ref_known-issues-7-1-1.adoc[leveloffset=+2]
 
+include::topics/svn-checkout-fails-issue-snippet.adoc[]
+
 include::topics/ref_resolved-issues-7-1-1.adoc[leveloffset=+2]
 
 [id="mta-7-1-0"]

--- a/docs/topics/eclipse-configuring-run.adoc
+++ b/docs/topics/eclipse-configuring-run.adoc
@@ -20,7 +20,6 @@ You can create multiple run configurations. Each run configuration must have a u
 . On the *Input* tab, complete the following fields:
 .. Select a migration path.
 .. Beside the *Projects* field, click *Add* and select one or more projects.
-.. Beside the *Packages* field, click *Add* and select one or more the packages.
 +
 [NOTE]
 ====

--- a/docs/topics/eclipse-configuring-run.adoc
+++ b/docs/topics/eclipse-configuring-run.adoc
@@ -20,6 +20,7 @@ You can create multiple run configurations. Each run configuration must have a u
 . On the *Input* tab, complete the following fields:
 .. Select a migration path.
 .. Beside the *Projects* field, click *Add* and select one or more projects.
+.. Beside the *Packages* field, click *Add* and select one or more the packages.
 +
 [NOTE]
 ====

--- a/docs/topics/svn-checkout-fails-issue-snippet.adoc
+++ b/docs/topics/svn-checkout-fails-issue-snippet.adoc
@@ -1,0 +1,5 @@
+// snippet
+
+.SVN Checkout fails when filenames have special characters
+
+The Subversion client fails when attempting a checkout operation in a repository that contains files with special characters in their filenames. link:https://issues.redhat.com/browse/MTA-4309[(MTA-4309)]


### PR DESCRIPTION
### JIRA

* [MTA-4309](https://issues.redhat.com/browse/MTA-4309)

See - [Slack discussion](https://redhat-internal.slack.com/archives/C02FNEJ9PLZ/p1733249537975539)


Creating a snippet to add to 7.1 release notes in the PR and the rebase [7.2 release notes PR](https://github.com/migtools/mta-documentation/pull/67) and add snippet