### PR TITLE
MTA 7.2.1 release notes fix

### DIFF
--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -18,6 +18,13 @@ include::topics/making-open-source-more-inclusive.adoc[]
 
 {ProductFullName} {DocInfoProductNumber} accelerates large-scale application modernization efforts across hybrid cloud environments on {ocp-first}. This solution provides insight throughout the adoption process, at both the portfolio and application levels: inventory, assess, analyze, and manage applications for faster migration to {ocp-short} through the user interface (UI) and command-line interface (CLI).
 
+[id="mta-7-2-1"]
+== {ProductShortName} 7.2.1
+
+include::topics/ref_resolved-issues-7-2-1.adoc[leveloffset=+2]
+
+include::topics/ref_known-issues-7-2-1.adoc[leveloffset=+2]
+
 
 [id="mta-7-2-0"]
 == {ProductShortName} 7.2.0
@@ -38,16 +45,6 @@ include::topics/analyzer-rbac-known-issue-snippet.adoc[]
 // include::topics/svn-checkout-fails-issue-snippet.adoc[]
 
 For a complete list of all known issues, see the list of link:https://issues.redhat.com/issues/?filter=12447880[{ProductShortName} 7.2.0 known issues] in Jira.
-
-
-
-[id="mta-7-2-0"]
-== {ProductShortName} 7.2.1
-
-include::topics/ref_resolved-issues-7-2-1.adoc[leveloffset=+2]
-
-include::topics/ref_known-issues-7-2-1.adoc[leveloffset=+2]
-
 
 
 :!release-notes:


### PR DESCRIPTION
There is a build error in the release notes
Line 45:
```
[id="mta-7-2-0"]
== {ProductShortName} 7.2.1
```

![image](https://github.com/user-attachments/assets/970b2af4-d405-4132-a2d5-41609691de81)

Duplicate ID, but it is not a major problem and i will get it fixed now