### PR TITLE
MTA-4748: Adding Vale to MTA GitHub repo

### DIFF
--- a/.github/workflows/lint-with-vale.yml
+++ b/.github/workflows/lint-with-vale.yml
@@ -1,0 +1,25 @@
+---
+name: Linting with Vale on pull request
+on: [pull_request]
+
+jobs:
+  vale:
+    name: Linting with Vale
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Asciidoctor
+        run: sudo apt-get install -y asciidoctor
+      - uses: errata-ai/vale-action@reviewdog
+        with:
+          filter_mode: diff_context
+          vale_flags: "--no-exit --minAlertLevel=error"
+          reporter: github-pr-review
+          # Radhika says not to block PR merge if there are Vale errors
+          # To change set fail_on_error: true
+          fail_on_error: false
+        env:
+          # Required, set by GitHub actions automatically:
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          REVIEWDOG_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/lint-with-vale.yml
+++ b/.github/workflows/lint-with-vale.yml
@@ -23,3 +23,4 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#about-the-github_token-secret
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           REVIEWDOG_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
+ 

--- a/vale.ini
+++ b/vale.ini
@@ -1,0 +1,40 @@
+StylesPath = .vale/styles
+
+MinAlertLevel = suggestion
+
+IgnoredScopes = code, tt, img, url, a, body.id
+
+SkippedScopes = script, style, pre, figure, code, tt, blockquote, listingblock, literalblock
+
+Packages = RedHat, proselint, write-good
+
+# Match AsciiDoc files. See: https://vale.sh/docs/topics/scoping/
+# Ignore files in a directory starting by `.`
+# to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
+[[!.]*.adoc]
+
+BasedOnStyles = RedHat, proselint, write-good
+
+[*.md]
+
+BasedOnStyles = RedHat, proselint, write-good
+
+# Ignore code surrounded by backticks or plus sign, parameters defaults, URLs.
+TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[)
+
+# Match INI files. See: https://vale.sh/docs/topics/scoping/
+[*.ini]
+
+BasedOnStyles = RedHat
+
+# Ignore code surrounded by backticks or plus sign, parameters defaults, URLs.
+TokenIgnores = (\x60[^\n\x60]+\x60), ([^\n]+=[^\n]*), (\+[^\n]+\+), (http[^\n]+\[)
+
+# Disabling rules (NO)
+RedHat.CaseSensitiveTerms = NO
+RedHat.ConfigMap = NO
+RedHat.Definitions = NO
+RedHat.Slash = NO
+RedHat.Spacing = NO
+RedHat.Spelling = NO
+RedHat.TermsSuggestions = NO


### PR DESCRIPTION
### JIRA

* [MTA-4748](https://issues.redhat.com/browse/MTA-4748)

### DESCRIPTION

With this PR, I am adding a GitHub workflow action. 

I am adding a `vale.ini` at the root level of the repo and a `lint-with-vale.yml`, in the `.github/workflows` directory,  to define the workflow.

### vale.ini

The `vale.ini` is set to include Red Hat styles and two other linters to improve grammar and spelling:

```
BasedOnStyles = RedHat, proselint, write-good
```

### lint-with-vale.yml

This is set to fire on `pull_request` 

