### PR TITLE
MTA-4798: Support for Listing Languages in 7.3.0

### DIFF
--- a/docs/topics/mta-cli-analyze.adoc
+++ b/docs/topics/mta-cli-analyze.adoc
@@ -13,7 +13,7 @@
 
 [source,terminal,subs="attributes+"]
 ----
-{mta-cli} analyze --input=<path_to_source_code> --output=<path_to_output_directory>
+{mta-cli} analyze --input <path_to_source_code> --output <path_to_output_directory>
 ----
 
 All flags:
@@ -46,6 +46,9 @@ Flags:
       --jaeger-endpoint (string)          Jaeger endpoint to collect traces.
       --json-output                       Create analysis and dependency
                                           output as JSON.
+      --list-languages                    List all langauges in the source 
+                                          application. This flag is not 
+                                          supported for binary applications.                
       --list-sources                      List available migration sources.
       --list-targets                      List available migration targets.
   -l, --label-selector (string)           Run rules based on specified label
@@ -99,17 +102,24 @@ The list of flags above does not include the `--bulk` flag because this flag is 
 .Usage example
 
 . Get an example application to run analysis on.
+. List all languages in the source application:
++
+[source,terminal,subs="attributes+"]
+----
+$ {mta-cli} analyze --input <path_to_application> --list-languages
+----
++
 . List available target technologies.
 +
 [source,terminal,subs="attributes+"]
 ----
-{mta-cli} analyze --list-targets
+$ {mta-cli} analyze --list-targets
 ----
 . Run an analysis with a specified target technology, for example `cloud-readiness`.
 +
 [source,terminal,subs="attributes+"]
 ----
-{mta-cli} analyze --input=<path-to/example-applications/example-1> --output=<path-to-output-dir> --target=cloud-readiness
+$ {mta-cli} analyze --input <path-to/example-applications/example-1> --output <path-to-output-dir> --target cloud-readiness
 ----
 . Several analysis reports are created in your specified output path:
 +

--- a/docs/topics/mta-cli-args.adoc
+++ b/docs/topics/mta-cli-args.adoc
@@ -76,6 +76,10 @@ a|`-l`, `--label-selector`
 |String
 |Flag to run rules based on a specified label selector expression.
 
+a|`--list-languages`
+|
+|Flag to list available languages in a source application.
+
 a|`--list-providers`
 |
 |Flag to list available supported providers.

--- a/docs/topics/mta-cli-run-single-app.adoc
+++ b/docs/topics/mta-cli-run-single-app.adoc
@@ -6,12 +6,28 @@
 [id="mta-cli-run-single-app_{context}"]
 = Running the {ProductShortName} {CLINameTitle} against an application
 
-You can run the {ProductFullName} {CLINameTitle} against an application.
+You can run the {ProductFullName} {CLINameTitle} against an application. 
+
+:FeatureName: The `--list-languages` flag
+include::developer-preview-feature.adoc[]
 
 .Procedure
 
 . Open a terminal and navigate to the `<{ProductShortName}_HOME>/` directory.
 
+. List all the languages in the source application by using the following command: 
++
+[source,terminal,subs="attributes+"]
+----
+$ ./{mta-cli} analyze --input <path_to_application> --list-languages
+----
+The listed langauages that do not have a supported provider require a custom rule set and the `--override-provider-settings` flag for analysis. 
++
+[NOTE]
+====
+The `--list-languages` flag is supported only for source applications.
+====
++
 . Run the `{mta-cli}` script, or `{mta-cli}.exe` for Windows, and specify the appropriate arguments:
 
 +


### PR DESCRIPTION
### JIRA

* [MTA-4798 Documentation for Support a new command in the CLI to return the language of the project](https://issues.redhat.com/browse/MTA-4798)

### VERSION

* 7.3.0

### PREVIEW
* [Running the MTA CLI against an application: Step 2](https://file.corp.redhat.com/pkylasam/mta-4798/html-single/#mta-cli-run-single-app_cli-guide)
* [Performing analysis using the command line: --list-language in flag list and procedure step 2](https://file.corp.redhat.com/pkylasam/mta-4798/html-single/#mta-cli-analyze_cli-guide)
* [A.1. About MTA command-line arguments](https://file.corp.redhat.com/pkylasam/mta-4798/html-single/#cli-args_cli-guide)