### PR TITLE
MTA-4958: Default memory values for the analyzer container are wrong

### DIFF
--- a/docs/topics/mta-7-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-7-installing-web-console-on-openshift.adoc
@@ -151,7 +151,7 @@ The most commonly used CR settings are listed in this table:
 |Maximum number of CPUs the pod is allowed to use
 
 |`analyzer_container_limits_memory`
-|`4Gi`
+|`1Gi`
 |Maximum amount of memory the pod is allowed to use. You can increase this limit if the pod displays `OOMKilled` errors.
 
 |`analyzer_container_requests_cpu`
@@ -159,7 +159,7 @@ The most commonly used CR settings are listed in this table:
 |Minimum number of CPUs the pod needs to run
 
 |`analyzer_container_requests_memory`
-|`4Gi`
+|`1Gi`
 |Minimum amount of memory the pod needs to run
 
 |`ui_container_limits_cpu`


### PR DESCRIPTION
### JIRA

* [MTA-4958](https://issues.redhat.com/browse/MTA-4958)


The CR settings table at the "Installing the Migration Toolkit for Applications Operator and the user interface" section reflects the following default values:

```
analyzer_container_requests_memory: 4Gi
analyzer_container_limits_memory: 4Gi
```

After checking, it has been found that the correct values are as follows:
```
analyzer_container_requests_memory: 1Gi
analyzer_container_limits_memory: 1Gi
```

### PREVIEW

* [3. Installing the Migration Toolkit for Applications user interface](https://anarnold97.github.io/MTA-Preview/MTA/MTA-4958.html#mta-7-installing-web-console-on-openshift_user-interface-guide)