### PR TITLE
MTA 7.3.0: Removed rhsso_external_access in Tackle CR Setting

### DIFF
--- a/docs/topics/mta-7-installing-web-console-on-openshift.adoc
+++ b/docs/topics/mta-7-installing-web-console-on-openshift.adoc
@@ -142,10 +142,6 @@ The most commonly used CR settings are listed in this table:
 |NA
 |Storage class requested for the Tackle RW0 volumes
 
-|`rhsso_external_access`
-|`False`
-|Flag to indicate whether a dedicated route is created to access the {ProductShortName} managed RHSSO instance
-
 |`analyzer_container_limits_cpu`
 |`1`
 |Maximum number of CPUs the pod is allowed to use


### PR DESCRIPTION
Removed `rhsso_external_access` in the [Tackle CR Setting table](https://docs.redhat.com/en/documentation/migration_toolkit_for_applications/7.3/html/user_interface_guide/mta-7-installing-web-console-on-openshift_user-interface-guide#installing-mta-operator-and-ui_user-interface-guide).