### PR TITLE
Attributes updates for MTA 7.3.2

### DIFF
--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -26,11 +26,11 @@ ifdef::mta[]
 :WebNameTitle: User Interface
 :WebNameURL: user_interface_guide
 :WebConsoleBookName: {WebNameTitle} Guide
-:ProductVersion: 7.3.1
+:ProductVersion: 7.3.2
 :PluginName: MTA plugin
 // :MavenProductVersion: 7.0.0.GA-redhat-00001
-:ProductDistributionVersion: 7.3.1.GA-redhat
-:ProductDistribution: mta-7.3.1.GA-cli-offline.zip
+:ProductDistributionVersion: 7.3.2.GA-redhat
+:ProductDistribution: mta-7.3.2.GA-cli-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download
 :IDEPluginFilename: migrationtoolkit-mta-eclipse-plugin-repository
 :JiraWindupURL: https://issues.redhat.com/projects/MTA/issues


### PR DESCRIPTION
Tracked under [MTA-5304](https://issues.redhat.com/browse/MTA-5304).

Checked the OCP versions in the [spreadsheet](https://docs.google.com/spreadsheets/d/19bRYespPb-AvclkwkoizmJ6NZ54p9iFRn6DGD8Ugv2c/edit?gid=1587698867#gid=1587698867) as well. No change to the attributes as of now.