### PR TITLE
Adding Link Checker

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,14 @@
+# This is a basic workflow to help you get started with Actions
+
+on: [pull_request]
+name: Check links for modified files
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        check-modified-files-only: 'yes'


### PR DESCRIPTION
This PR should implement a GitHub action that checks files for broken links.

The script is built with the following inputs:

|Section             |Script                          |Explanation             |
|--------------------|----------------------------------------------------------|----------------------------------------------|
|Event Trigger       |on: [pull_request]    |Specifies that this workflow should run automatically whenever a pull_request event occurs (e.g., when a pull request is created, synchronized, or reopened).      |
|Workflow Name       |name: Check links for modified files    |A descriptive name for the entire workflow, visible in the GitHub Actions tab.    |
|Jobs Definition  |jobs:  |Begins the definition of the tasks (jobs) that will execute in the workflow.       |
|Job ID     |markdown-link-check:      |The unique identifier for this specific job.      |
|Runner Environment  |runs-on: ubuntu-latest       |Defines the environment where the job will execute—in this case, the latest version of an Ubuntu Linux virtual machine hosted by GitHub.   |
|Steps Definition    |steps:  |A sequence of individual tasks (steps) to be executed within the markdown-link-check job.   |
|Step 1: Checkout    |- uses: actions/checkout@v4       |Uses the official checkout action to download the repository's code onto the runner environment so the subsequent steps can access the files.     |
|Step 2: Link Checker|- uses: gaurav-nelson/github-action-markdown-link-check@v1|Executes a third-party action designed to check links within files.  |
|Action Inputs       |with:        |Passes configuration parameters (inputs) to the link-checking action.    |
|Quiet Mode          |use-quiet-mode: 'yes'       |Instructs the link-checking action to suppress non-essential output. (Note: This setting might be overridden or combined strangely with verbose mode depending on the action's logic).   |
|Verbose Mode        |use-verbose-mode: 'yes'     |Instructs the link-checking action to print detailed output, which usually includes more information about the checking process and any encountered errors.      |
|Target Files        |check-modified-files-only: 'yes'   |This is the crucial setting: it tells the link checker to only check links in Markdown files that were modified as part of the current pull request (i.e., the files that are different between the base branch and the PR branch). This makes the check much faster and more focused.|

Once merged it will create a new GitHub action.

