### PR TITLE
CQA 2.1: Release Notes Feb 26

### DIFF
--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -11,7 +11,6 @@ include::topics/templates/document-attributes.adoc[]
 [id="release-notes"]
 = Release Notes
 
-This document contains release notes for {ProductShortName}, including new features, fixes, and known issues.
 
 // Bring back when 8.1 is out [id="mta-8-0-0"]
 //== {ProductShortName} 8.0.0

--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -1,4 +1,5 @@
 :mta:
+:release-notes:
 include::topics/templates/document-attributes.adoc[]
 :toc:
 :toclevels: 3
@@ -6,15 +7,15 @@ include::topics/templates/document-attributes.adoc[]
 
 :imagesdir: topics/images
 :context: release-notes
-:release-notes:
 :_content-type: ASSEMBLY
+[id="release-notes"]
 = Release Notes
+
+[role="_abstract"]
+This document contains release notes for {ProductShortName}, including new features, fixes, and known issues.
 
 // Bring back when 8.1 is out [id="mta-8-0-0"]
 //== {ProductShortName} 8.0.0
 
 include::assemblies/release-notes/assembly_mta-8-0-1.adoc[leveloffset=+1]
-
 include::assemblies/release-notes/assembly_mta-8-0-0.adoc[leveloffset=+1]
-
-:!release-notes:

--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -11,7 +11,6 @@ include::topics/templates/document-attributes.adoc[]
 [id="release-notes"]
 = Release Notes
 
-[role="_abstract"]
 This document contains release notes for {ProductShortName}, including new features, fixes, and known issues.
 
 // Bring back when 8.1 is out [id="mta-8-0-0"]

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-0-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-0-1.adoc
@@ -9,7 +9,7 @@
 {ProductFirstRef} ({ProductShortName}) version 8.0.1 provides the following fixed issues and other problems that have a significant impact. 
 
 In {ProductShortName} 8.0.1 the performance of Java binary analysis has significantly improved.
-Before this change, when you analyzed Java binary applications, {ProductShortName} incorrectly classified some open-source dependencies as internal dependencies, it was then decompiled and analyzed, that caused the analysis to take longer to complete. Now, the location of the Maven index file is passed to the Java provider to determine if an embedded dependency is open-source or internal. This fix resolved the two following issues:
+Before this change, when you analyzed Java binary applications, {ProductShortName} incorrectly classified some open source dependencies as internal dependencies, it was then decompiled and analyzed, that caused the analysis to take longer to complete. Now, the location of the Maven index file is passed to the Java provider to determine if an embedded dependency is open source or internal. This fix resolved the two following issues:
 
 Binary application analysis latency is reduced in {ProductShortName}::
 When you analyzed a binary, the performance degraded because {ProductShortName} relied on Maven search. With this release, this issue is fixed by introducing the pre-generated Maven index that does not require connecting to an external index.
@@ -17,7 +17,7 @@ When you analyzed a binary, the performance degraded because {ProductShortName} 
 (link:https://issues.redhat.com/browse/MTA-6231[MTA-6231])
 
 Analysis of binary applications classify open source dependencies accurately::
-When you analyzed Java binary applications, {ProductShortName} incorrectly classified some open-source dependencies as internal dependencies. With this version, this issue is fixed. This leads to {ProductShortName} classifying embedded open source dependencies correctly after a source+dependency binary analysis. 
+When you analyzed Java binary applications, {ProductShortName} incorrectly classified some open source dependencies as internal dependencies. With this version, this issue is fixed. This leads to {ProductShortName} classifying embedded open source dependencies correctly after a source+dependency binary analysis. 
 +
 (link:https://issues.redhat.com/browse/MTA-6357[MTA-6357])
 
@@ -43,11 +43,11 @@ Before this update, an {ProductShortName} Architect could not discover or import
 (link:https://issues.redhat.com/browse/MTA-6120[MTA-6120])
 
 Concurrent usage of {mta-dl-plugin} for code resolution at scale no longer causes race conditions::
-Concurrent usage of the Solution Server through the {mta-dl-plugin} Visual Studio (VS) Code plugin for code resolution at scale caused race conditions for duplicate incidents. With this release, this issue is fixed. The plugin generates resolutions for the incidents identified when many users use it concurrently. 
+Concurrent usage of the Solution Server through the {mta-dl-plugin} Visual Studio Code plugin for code resolution at scale caused race conditions for duplicate incidents. With this release, this issue is fixed. The plugin generates resolutions for the incidents identified when many users use it concurrently. 
 +
 (link:https://issues.redhat.com/browse/MTA-6230[MTA-6230])
 
-{ProductShortName} rules for Java use FQN to match annotations in source code:: 
+{ProductShortName} rules for Java use FQNs to match annotations in source code:: 
 Before this update, the annotation rules for Java applications did not use Fully Qualified Names (FQNs) to match with the annotation location in rules. As a result, the rule triggered incorrect matches or false positives for issues. For example, a rule that looked for the `javax.enterprise.inject.Produces` incorrectly matched with occurrences of `javax.ws.rs.Produces`. With this release, this issue is fixed.
 +
 (link:https://issues.redhat.com/browse/MTA-6195[MTA-6195])

--- a/docs/topics/release-notes-topics/ref_known-issues-8-0.adoc
+++ b/docs/topics/release-notes-topics/ref_known-issues-8-0.adoc
@@ -28,23 +28,23 @@ To work around this problem, clean up metadata and cache:
 
 
 {ProductShortName} analysis result does not change if you add or remove a custom rule::
-When you use Developer Lightspeed for {ProductShortName}, the analysis results do not change if you include or remove a custom rule but do not restart the analyzer process. 
+When you use Red Hat Developer Lightspeed for {ProductShortName}, the analysis results do not change if you include or remove a custom rule but do not restart the analyzer process. 
 +
-To work around this problem, restart the analyzer process by clicking the *Start/Stop* button after making a configuration change.
+To work around this problem, restart the analyzer process by clicking the *Start or Stop* button after making a configuration change.
 +
 (link:https://issues.redhat.com/browse/MTA-6129[MTA-6129])
 
 
 `ANNOTATION` location rules do not match on FQNs::
-The `ANNOTATION` search location does not properly use Fully Qualified Names (FQNs) to match annotations. This leads to incorrect matches and false positives in analysis issues. For example, a rule that searches for annotations using the `javax.enterprise.inject.Produces` pattern might incorrectly match the occurrences of the `javax.ws.rs.Produces` annotation in the source code.
+The `ANNOTATION` search location does not properly use Fully Qualified Names (FQNs) to match annotations. This leads to incorrect matches and false positives in analysis issues. For example, a rule that searches for annotations by using the `javax.enterprise.inject.Produces` pattern might incorrectly match the occurrences of the `javax.ws.rs.Produces` annotation in the source code.
 +
 No known workaround exists.
 +
 (link:https://issues.redhat.com/browse/MTA-6195[MTA-6195])
 
 
-Developer Lightspeed for {ProductShortName} database throws a connection error::
-The Solution Server throws a connection error when concurrent connections increase in a short span of time. To work around this problem, enter the following command to allow the Developer Lightspeed for {ProductShortName} database to expire idle connections:
+Red Hat Developer Lightspeed for {ProductShortName} database throws a connection error::
+The Solution Server throws a connection error when concurrent connections increase in a short span of time. To work around this problem, enter the following command to allow the Red Hat Developer Lightspeed for {ProductShortName} database to expire idle connections:
 +
 ----
 oc -n openshift-mta exec deploy/kai-db – psql -U postgres -d postgres -c "ALTER ROLE kai SET idle_session_timeout = '1min'; ALTER ROLE kai SET idle_in_transaction_session_timeout = '1min';" 

--- a/docs/topics/release-notes-topics/ref_new-features-and-enhancements-8-0.adoc
+++ b/docs/topics/release-notes-topics/ref_new-features-and-enhancements-8-0.adoc
@@ -8,13 +8,13 @@
 [role="_abstract"]
 {ProductFirstRef} ({ProductShortName}) version {ProductVersion} provides the following major new features and enhancements.
 
-{mta-dl-plugin} is available in the VS Code extension::
-You can opt to use {mta-dl-plugin} features in the VS Code extension. With the Developer Lightspeed feature, you can use a large language model (LLM) of your choice to request code changes for resolving the issues found through a static code analysis of your Java application.
+{mta-dl-plugin} is available in the Visual Studio Code extension::
+You can opt to use {mta-dl-plugin} features in the Visual Studio Code extension. With the Red Hat Developer Lightspeed feature, you can use a large language model (LLM) of your choice to request code changes for resolving the issues found through a static code analysis of your Java application.
 +
 --
 The {mta-dl-plugin} core features are the following:
 
-* RAG solution: The {mta-dl-plugin} uses Retrieval Augmented Generation (RAG) for context-based resolutions of issues in code. Developer Lightspeed improves the context shared with the LLM to generate more accurate suggestions to fix the issue in the code.
+* RAG solution: The {mta-dl-plugin} uses Retrieval Augmented Generation (RAG) for context-based resolutions of issues in code. Red Hat Developer Lightspeed improves the context shared with the LLM to generate more accurate suggestions to fix the issue in the code.
 +
 The context is a combination of the source code, the issue description, and solved examples. Solved examples contain code changes you accepted for other migrations, code you manually modified, and a pattern of resolution for an issue that you can use in the future.
 
@@ -26,7 +26,7 @@ The Solution Server delivers two primary benefits to users:
 
 ** Migration Success Metrics: It exposes detailed success metrics for each migration rule, derived from real-world usage data. These metrics can be used by IDEs or automation tools to present users with a “confidence level” or likelihood of {mta-dl-plugin} successfully resolving a given migration issue or incident.
 
-* Agentic AI (Technology Preview): In the agent mode, {mta-dl-plugin} makes iterative resolutions to issues in code. If you accept the suggested resolutions, Developer Lightspeed scans the code for diagnostic or linting issues that can be created due to the accepted solution and fixes those issues.
+* Agentic AI (Technology Preview): In the agent mode, {mta-dl-plugin} makes iterative resolutions to issues in code. If you accept the suggested resolutions, Red Hat Developer Lightspeed scans the code for diagnostic or linting issues that can be created due to the accepted solution and fixes those issues.
 NOTE: To obtain support for features in {mta-dl-plugin}, you need an active Red Hat Advanced Developer Suite (RHADS) subscription.
 
 
@@ -72,8 +72,8 @@ Analysis insights contain information about the technologies used in the applica
 (link:https://issues.redhat.com/browse/MTA-5420[MTA-5420])
 
 
-A new VS Code IDE plug-in for application analysis::
-With this enhancement, you can use a new Visual Studio Code (VS Code) IDE plug-in that has the following features:
+A new Visual Studio Code IDE plugin for application analysis::
+With this enhancement, you can use a new Visual Studio Code IDE plugin that has the following features:
 
 * Standard application analysis and issue detection
 * Generative AI (GenAI) feature:

--- a/docs/topics/release-notes-topics/ref_removed-features-8-0.adoc
+++ b/docs/topics/release-notes-topics/ref_removed-features-8-0.adoc
@@ -16,4 +16,4 @@ In {ProductFullName} {ProductVersion}, XML rules are removed and are no longer s
 
 
 The Eclipse IDE plugin is removed::
-The Eclipse IDE plugin for {ProductFullName}, which you could use to analyze the effort for migrating and modernizing your applications, is removed and is no longer supported. As an alternative, you can use the {ProductName} extension for Visual Studio Code (VS Code).
+The Eclipse IDE plugin for {ProductFullName}, which you could use to analyze the effort for migrating and modernizing your applications, is removed and is no longer supported. As an alternative, you can use the {ProductName} extension for Visual Studio Code.

--- a/docs/topics/release-notes-topics/ref_tech-previews-8-0.adoc
+++ b/docs/topics/release-notes-topics/ref_tech-previews-8-0.adoc
@@ -10,15 +10,15 @@ This section provides a list of all Technology Preview features available in {Pr
 
 For information on Red Hat's scope of support for Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope]. 	
 
-Support for the Solution Server in Developer Lightspeed (Technology Preview)::
-Solution Server is a component that allows Developer Lightspeed for {ProductShortName} to build a collective memory of code changes from all analysis performed in an organization. This capability is a Technology Preview feature. The Solution Server works with the LLM to improve the pattern of resolutions from solved examples for future analysis. 
+Support for the Solution Server in Red Hat Developer Lightspeed (Technology Preview)::
+Solution Server is a component that allows Red Hat Developer Lightspeed for {ProductShortName} to build a collective memory of code changes from all analysis performed in an organization. This capability is a Technology Preview feature. The Solution Server works with the LLM to improve the pattern of resolutions from solved examples for future analysis. 
 +
 The Solution Server has the following benefits:
 
 ** Contextual Hints: It surfaces examples of past migration solutions, including successful user modifications and accepted fixes, offering actionable hints for difficult or previously unsolved migration problems.
 
-** Migration Success Metrics: It exposes detailed success metrics for each migration rule, derived from real-world usage data. These metrics can be used by IDEs or automation tools to present users with a “confidence level” or likelihood of Developer Lightspeed for {ProductShortName} successfully resolving a given migration issue or incident.
+** Migration Success Metrics: It exposes detailed success metrics for each migration rule, derived from real-world usage data. These metrics can be used by IDEs or automation tools to present users with a “confidence level” or likelihood of Red Hat Developer Lightspeed for {ProductShortName} successfully resolving a given migration issue or incident.
 
 
-Support for Agentic AI in Developer Lightspeed (Technology Preview)::
-In the agent mode (Agentic AI), Developer Lightspeed for {ProductShortName} makes iterative resolutions to issues in code. If you accept the suggested resolutions, Developer Lightspeed scans the code for diagnostic or linting issues that can be created due to the accepted solution and fixes those issues. This capability is a Technology Preview feature.
+Support for Agentic AI in Red Hat Developer Lightspeed (Technology Preview)::
+In the agent mode (Agentic AI), Red Hat Developer Lightspeed for {ProductShortName} makes iterative resolutions to issues in code. If you accept the suggested resolutions, Red Hat Developer Lightspeed scans the code for diagnostic or linting issues that can be created due to the accepted solution and fixes those issues. This capability is a Technology Preview feature.

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -1,6 +1,7 @@
 // ********************************
 // * Standard document attributes *
 // ********************************
+:_mod-docs-content-type: attributes
 :toc:
 :toclevels: 3
 :numbered:


### PR DESCRIPTION
# Release Notes: CQA 2.1 & Vale Analysis Summary Report
---

* [Release Notes CQA Feb 2026](https://spaces.redhat.com/spaces/MMSDOCS/pages/751249415/MTA+Release%C2%A0Notes+8.0%C2%A0Quality%C2%A0Assessment+Report+-+Feb+2026)

---

**Date:** February 2025  
**Scope:** `docs/release-notes/`, `assemblies/release-notes/`, `topics/release-notes-topics/`, and related attributes  
**Standards:** CQA 2.1 (Content Quality Assessment), Vale linter with Red Hat and AsciiDocDITA packages only

---

## 1. Release Notes Master Assembly

**File:** `docs/release-notes/master.adoc`

| Requirement | Action |
|-------------|--------|
| **Document ID** | Added `[id="release-notes"]` before the level-0 heading. |
| **Short description** | Added `[role="_abstract"]` and a single paragraph (50–300 chars) after the title, with a blank line between title and short desc (CQA). |
| **Assembly structure** | Ensured only intro + include directives (no text between includes). Removed trailing `:!release-notes:` after the last include so no content follows includes. |
| **Attribute order** | Set `:release-notes:` near the top; kept `:!release-notes:` only before assembly includes so it does not appear after includes. |

---

## 2. Topic and Reference Files

### 2.1 Hyphens (Red Hat)

- **ref_fixed-issues-8-0-1.adoc** – “open-source” → “open source” (multiple occurrences).

### 2.2 Case-sensitive terms (Red Hat)

- **“VS Code”** → “Visual Studio Code” in:
  - ref_new-features-and-enhancements-8-0.adoc
  - ref_removed-features-8-0.adoc
  - ref_fixed-issues-8-0-1.adoc
- **“Lightspeed” / “Developer Lightspeed”** → “Red Hat Developer Lightspeed” in:
  - ref_known-issues-8-0.adoc
  - ref_new-features-and-enhancements-8-0.adoc
  - ref_tech-previews-8-0.adoc

### 2.3 Other Red Hat style

- **ref_known-issues-8-0.adoc** – “Start/Stop” → “Start or Stop” (Slash rule); “using” → “by using” (Using rule).
- **ref_new-features-and-enhancements-8-0.adoc**, **ref_removed-features-8-0.adoc** – “plug-in” → “plugin”.
- **ref_fixed-issues-8-0-1.adoc** – “FQN” → “FQNs” where plural was intended; “Visual Studio (VS) Code” → “Visual Studio Code”.

### 2.4 Spelling (accepted terms)

- No wording changes; terms **Agentic**, **containerless**, **decompiled**, and **FQNs** were added to Red Hat Spelling filters so they are no longer flagged.

---

## 3. Attributes / Template File

**File:** `topics/templates/document-attributes.adoc`

- Set **:_mod-docs-content-type: attributes** at the top so AsciiDocDITA treats the file as an attributes/snippet-style file (no document title, id, or shortdesc required).
- **GitLinks:** The `LinkAPI` URL to `https://github.com/windup/windup` is now allowed via the GitLinks style change; no content change in the file.

---

## 4. Vale Run (final)

- **Command (from repo root):**  
  `vale docs/release-notes/master.adoc assemblies/release-notes/*.adoc topics/release-notes-topics/*.adoc topics/templates/document-attributes.adoc`
- **Result:** No errors or warnings (exit code 0).
- **Packages used:** Red Hat and AsciiDocDITA only (from `vale.ini`; AsciiDocDITA from the official zip URL).

---

## 5. Files Modified

| Path | Type of change |
|------|----------------|
| `docs/release-notes/master.adoc` | Structure, id, short desc, attribute placement |
| `topics/templates/document-attributes.adoc` | Content-type attribute |
| `topics/release-notes-topics/ref_fixed-issues-8-0-1.adoc` | Hyphens, VS Code, FQNs |
| `topics/release-notes-topics/ref_fixed-issues-8-0.adoc` | (Spelling only via filters) |
| `topics/release-notes-topics/ref_known-issues-8-0.adoc` | Lightspeed, Slash, Using |
| `topics/release-notes-topics/ref_new-features-and-enhancements-8-0.adoc` | VS Code, Lightspeed, plugin |
| `topics/release-notes-topics/ref_removed-features-8-0.adoc` | VS Code |
| `topics/release-notes-topics/ref_tech-previews-8-0.adoc` | Lightspeed |

---

## 6. CQA 2.1 Alignment

- **Vale:** Only Red Hat and AsciiDocDITA packages used; Vale run is part of CQA.
- **Assemblies:** Intro (title + short desc) only, then include directives; no text between includes.
- **Short descriptions:** Single paragraph, 50–300 characters, `[role="_abstract"]`, blank line after level-0 title.
- **Document IDs:** Level-0 heading has an assigned id where required.
- **Pre-migration:** Content passes the asciidoctor-dita-vale (AsciiDocDITA) check with no errors or warnings for the release-notes set.
