### PR TITLE
[MTA] [RN] Release notes for MTA 8.1.1

### DIFF
--- a/assemblies/release-notes/assembly_mta-8-1-0.adoc
+++ b/assemblies/release-notes/assembly_mta-8-1-0.adoc
@@ -1,5 +1,5 @@
-:_newdoc-version: 2.18.5
-:_template-generated: 2026-02-04
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-04-08
 :_mod-docs-content-type: ASSEMBLY
 
 ifdef::context[:parent-context-of-mta-8-1-0: {context}]
@@ -10,13 +10,13 @@ endif::[]
 ifdef::context[]
 [id="mta-8-1-0_{context}"]
 endif::[]
-= {ProductFirstRef} 8.1
+= {ProductShortName} 8.1.0
 
 :context: mta-8-1-0
 
 [role="_abstract"]
-This Release Notes section provides high-level coverage of the improvements and additions that have been implemented in {ProductFullName} 8.1.
- 
+The {ProductShortName} 8.1.0 section lists the new features and enhancements, Technology Preview features, removed features, fixed issues, and known issues.
+
 include::topics/release-notes-topics/ref_new-features-and-enhancements-8-1-0.adoc[leveloffset=+1]
 
 include::topics/release-notes-topics/ref_dev-preview-8-1-0.adoc[leveloffset=+1]
@@ -26,7 +26,6 @@ include::topics/release-notes-topics/ref_known-issues-8-1-0.adoc[leveloffset=+1]
 
 include::topics/release-notes-topics/ref_fixed-issues-8-1-0.adoc[leveloffset=+1]
 
- 
 ifdef::parent-context-of-mta-8-1-0[:context: {parent-context-of-mta-8-1-0}]
 ifndef::parent-context-of-mta-8-1-0[:!context:]
 

--- a/assemblies/release-notes/assembly_mta-8-1-1.adoc
+++ b/assemblies/release-notes/assembly_mta-8-1-1.adoc
@@ -1,0 +1,24 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-04-08
+:_mod-docs-content-type: ASSEMBLY
+
+ifdef::context[:parent-context-of-mta-8-1-1: {context}]
+
+ifndef::context[]
+[id="mta-8-1-1"]
+endif::[]
+ifdef::context[]
+[id="mta-8-1-1_{context}"]
+endif::[]
+= {ProductShortName} 8.1.1
+
+:context: mta-8-1-1
+
+[role="_abstract"]
+The {ProductShortName} 8.1.1 section lists the new features and enhancements, Technology Preview features, removed features, fixed issues, and known issues.
+
+//include::
+
+ifdef::parent-context-of-mta-8-1-1[:context: {parent-context-of-mta-8-1-1}]
+ifndef::parent-context-of-mta-8-1-1[:!context:]
+

--- a/assemblies/release-notes/assembly_mta-8-1-1.adoc
+++ b/assemblies/release-notes/assembly_mta-8-1-1.adoc
@@ -17,7 +17,7 @@ endif::[]
 [role="_abstract"]
 The {ProductShortName} 8.1.1 section lists the new features and enhancements, Technology Preview features, removed features, fixed issues, and known issues.
 
-//include::
+include::topics/release-notes-topics/ref_fixed-issues-8-1-1.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-mta-8-1-1[:context: {parent-context-of-mta-8-1-1}]
 ifndef::parent-context-of-mta-8-1-1[:!context:]

--- a/assemblies/release-notes/assembly_mta-8-1-1.adoc
+++ b/assemblies/release-notes/assembly_mta-8-1-1.adoc
@@ -15,7 +15,7 @@ endif::[]
 :context: mta-8-1-1
 
 [role="_abstract"]
-The {ProductShortName} 8.1.1 section lists the new features and enhancements, Technology Preview features, removed features, fixed issues, and known issues.
+The {ProductShortName} 8.1.1 section lists the issues fixed in this release.
 
 include::topics/release-notes-topics/ref_fixed-issues-8-1-1.adoc[leveloffset=+1]
 

--- a/assemblies/release-notes/assembly_mta-8-1.adoc
+++ b/assemblies/release-notes/assembly_mta-8-1.adoc
@@ -1,0 +1,26 @@
+:_newdoc-version: 2.18.5
+:_template-generated: 2026-02-04
+:_mod-docs-content-type: ASSEMBLY
+
+ifdef::context[:parent-context-of-mta-8-1-0: {context}]
+
+ifndef::context[]
+[id="mta-8-1-0"]
+endif::[]
+ifdef::context[]
+[id="mta-8-1-0_{context}"]
+endif::[]
+= {ProductFirstRef} 8.1
+
+:context: mta-8-1
+ 
+[role="_abstract"]
+This Release Notes section provides high-level coverage of the improvements and additions that have been implemented in {ProductFullName} 8.1.
+
+include::assembly_mta-8-1-1.adoc[leveloffset=+1]
+
+include::assembly_mta-8-1-0.adoc[leveloffset=+1]
+
+ifdef::parent-context-of-mta-8-1-0[:context: {parent-context-of-mta-8-1-0}]
+ifndef::parent-context-of-mta-8-1-0[:!context:]
+

--- a/assemblies/release-notes/assembly_mta-8-1.adoc
+++ b/assemblies/release-notes/assembly_mta-8-1.adoc
@@ -23,4 +23,3 @@ include::assembly_mta-8-1-0.adoc[leveloffset=+1]
 
 ifdef::parent-context-of-mta-8-1-0[:context: {parent-context-of-mta-8-1-0}]
 ifndef::parent-context-of-mta-8-1-0[:!context:]
-

--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -15,6 +15,6 @@ include::assemblies/release-notes/assembly_mta-8-1.adoc[leveloffset=+1]
 
 include::assemblies/release-notes/assembly_mta-8-0.adoc[leveloffset=+1]
 
- 
+
 :!release-notes:
  

--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -11,10 +11,10 @@ include::topics/templates/document-attributes.adoc[]
 = Release Notes
 
 
-include::assemblies/release-notes/assembly_mta-8-1-0.adoc[leveloffset=+1]
+include::assemblies/release-notes/assembly_mta-8-1.adoc[leveloffset=+1]
 
 include::assemblies/release-notes/assembly_mta-8-0.adoc[leveloffset=+1]
 
-
+ 
 :!release-notes:
  

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-1-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-1-1.adoc
@@ -15,7 +15,7 @@ Before this update, the Application discovery manifest in the {ProductFullName} 
 
 
 The {ProductShortName} UI generates assets for applications without a discovery manifest::
-Before this update, you could not generate assets for applications without an associated discovery manifest by using the {ProductFullName} user interface (UI). As a consequence, you could not generate assets for applications with only source code that had not been discovered in a source platform. With this update, {ProductShortName} supports generating assets for applications without a discovery manifest. As a result, you can use the {ProductShortName} UI to generate these assets, which enhances deployment flexibility.
+Before this update, the {ProductFullName} user interface (UI) did not allow you to generate assets for applications without an associated discovery manifest. As a consequence, you could not generate assets for applications with only source code that had not been discovered in a source platform. With this update, {ProductShortName} supports generating assets for applications without a discovery manifest. As a result, you can use the {ProductShortName} UI to generate these assets, which enhances deployment flexibility.
 +
 (link:https://redhat.atlassian.net/browse/MTA-6788[MTA-6788])
 

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-1-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-1-1.adoc
@@ -8,11 +8,14 @@
 [role="_abstract"]
 {ProductFirstRef} ({ProductShortName}) version 8.1.1 provides the following fixed issues that have a significant impact.
 
-//placeholder for MTA-6774
-
+The Application discovery manifest in the {ProductShortName} UI displays YAML-formatted content::
+Before this update, the Application discovery manifest in the {ProductFullName} user interface (UI) did not display YAML-formatted content. As a consequence, you could only see raw JSON data that included all database record metadata instead of formatted YAML. With this release, the Application discovery manifest includes only YAML-formatted content fields.
++
 (link:https://redhat.atlassian.net/browse/MTA-6774[MTA-6774])
 
 
-//placeholder for MTA-6788
-
+The {ProductShortName} UI generates assets for applications without a discovery manifest::
+Before this update, you could not generate assets for applications without an associated discovery manifest by using the {ProductFullName} user interface (UI). As a consequence, you could not generate assets for applications with only source code that had not been discovered in a source platform. With this update, {ProductShortName} supports generating assets for applications without a discovery manifest. As a result, you can use the {ProductShortName} UI to generate these assets, which enhances deployment flexibility.
++
 (link:https://redhat.atlassian.net/browse/MTA-6788[MTA-6788])
+

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-1-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-1-1.adoc
@@ -1,0 +1,18 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-04-15
+:_mod-docs-content-type: REFERENCE
+
+[id="fixed-issues-8-1-1_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+{ProductFirstRef} ({ProductShortName}) version 8.1.1 provides the following fixed issues that have a significant impact.
+
+//placeholder for MTA-6774
+
+(link:https://redhat.atlassian.net/browse/MTA-6774[MTA-6774])
+
+
+//placeholder for MTA-6788
+
+(link:https://redhat.atlassian.net/browse/MTA-6788[MTA-6788])


### PR DESCRIPTION
Tracked under https://redhat.atlassian.net/browse/MTA-6732

Preview: https://mpershina.github.io/Previews/MTA/8.1.1-RNs.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated MTA 8.1 release notes to list new features/enhancements, Technology Preview items, removed features, fixed issues, and known issues; reorganized content to include separate 8.1 and 8.1.1 sections.
  * Added MTA 8.1.1 release notes and a dedicated "Fixed issues" topic.
* **Bug Fixes**
  * 8.1.1: Application discovery manifest now displays YAML-formatted content; UI can generate assets for apps lacking a discovery manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->