### PR TITLE
MTA-6757 Formatting Fixes

### DIFF
--- a/docs/topics/mta-cli/ref_mta-cli-config-flags.adoc
+++ b/docs/topics/mta-cli/ref_mta-cli-config-flags.adoc
@@ -31,7 +31,6 @@ You can connect to the {ProductFullName} Hub and download profile bundles from t
 |`login`
 |
 |Use the command to enter the `host` URL, `username`, and the `password`. 
-+
 
 The `host` URL is the {ProductShortName} user interface URL. The username and password are the {ProductShortName} realm credentials.
 

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-0-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-0-1.adoc
@@ -17,7 +17,7 @@ When you analyzed a binary, the performance degraded because {ProductShortName} 
 (link:https://issues.redhat.com/browse/MTA-6231[MTA-6231])
 
 Analysis of binary applications classifies open source dependencies correctly::
-When you analyzed Java binary applications, {ProductShortName} incorrectly classified some open-source dependencies as internal dependencies. With this version, this issue is fixed. This leads to {ProductShortName} classifying embedded open source dependencies correctly after a source+dependency binary analysis. 
+When you analyzed Java binary applications, {ProductShortName} incorrectly classified some open-source dependencies as internal dependencies. With this version, this issue is fixed. This leads to {ProductShortName} classifying embedded open source dependencies correctly after a `source+dependency` binary analysis. 
 +
 (link:https://issues.redhat.com/browse/MTA-6357[MTA-6357])
 

--- a/docs/topics/rules-development/yaml-dotnet-provider.adoc
+++ b/docs/topics/rules-development/yaml-dotnet-provider.adoc
@@ -13,7 +13,7 @@ The `csharp` provider uses a gRPC interface to perform a semantic analysis of an
 
 == `referenced`
 
-The `csharp` provider supports `referenced` capability in rules to define fields such as `pattern` and `location` based on which the provider searches the code for violations. 
+The `csharp` provider supports the `referenced` capability in rules to define fields such as `pattern` and `location`. The provider uses these patterns to search the source code for violations. 
 
 [source,yaml]
 ----

--- a/docs/topics/rules-development/yaml-dotnet-provider.adoc
+++ b/docs/topics/rules-development/yaml-dotnet-provider.adoc
@@ -4,17 +4,17 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="yaml-dotnet-provider_{context}"]
-= C# provider
+= Csharp provider
 
 [role="_abstract"]
-The `C#` provider is an external provider used to analyze `.NET Core` and `C#` source code. Currently, the provider supports the `referenced` capability.
+The `csharp` provider is an external provider used to analyze `.NET Core` and `C#` source code. Currently, the provider supports the `referenced` capability.
 
-The `C#` provider uses a gRPC interface to perform a semantic analysis of an application source code in the `source-only` mode. The provider parses the source code by using tree-sitter and uses stack graph for the analysis to find references to types, methods, classes, and fields. Based on the `C#` custom rule definition, the analyzer identifies violations in your code that you must resolve before the application migration. 
+The `csharp` provider uses a gRPC interface to perform a semantic analysis of an application source code in the `source-only` mode. The provider parses the source code by using tree-sitter and uses stack graph for the analysis to find references to types, methods, classes, and fields. Based on the custom rule definition, the analyzer identifies violations in your code that you must resolve before the application migration. 
 
 == `referenced`
 
-The `C#` provider supports `referenced` capability in rules to define fields such as `pattern` and `location` based on which the provider searches the code for violations. 
-+
+The `csharp` provider supports `referenced` capability in rules to define fields such as `pattern` and `location` based on which the provider searches the code for violations. 
+
 [source,yaml]
 ----
 when:
@@ -22,7 +22,6 @@ when:
     pattern: "<pattern>" 
     location: CLASS 
 ----
-+
 where:
 
 * `pattern` is a regular expression pattern to match the required reference, for example, `HttpNotFound`.


### PR DESCRIPTION
### JIRA

* [MTA-6757 Formatting Errors](https://redhat.atlassian.net/browse/MTA-6757)

### Version

* 8.2.0

### Previews

* [Config command options removed '+' for indentation](https://pkylas007.github.io/Preview/MTA/mta-6757-cli/index.html#mta-cli-config-flags_analyzing-apps-profiles)
* [3.6. Csharp provider](https://pkylas007.github.io/Preview/MTA/mta-6757-rules-dev/index.html#yaml-dotnet-provider_rules-prov-cond)
* [2.1.2. Fixed issues Corrected the source+dependency formatting issue](https://pkylas007.github.io/Preview/MTA/mta-6757-release-notes/index.html#fixed-issues-8-0-1_mta-8-0-1)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Removed a formatting artifact in CLI configuration reference for clearer option descriptions.
  * Improved inline code formatting in release notes to clarify a binary analysis term.
  * Standardized provider naming and related formatting in provider development documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->