### PR TITLE
[MTA] [RN] Release notes and attributes for MTA 8.1.2

### DIFF
--- a/assemblies/release-notes/assembly_mta-8-1-2.adoc
+++ b/assemblies/release-notes/assembly_mta-8-1-2.adoc
@@ -1,0 +1,24 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-05-06
+:_mod-docs-content-type: ASSEMBLY
+
+ifdef::context[:parent-context-of-mta-8-1-2: {context}]
+
+ifndef::context[]
+[id="mta-8-1-2"]
+endif::[]
+ifdef::context[]
+[id="mta-8-1-2_{context}"]
+endif::[]
+= {ProductShortName} 8.1.2
+
+:context: mta-8-1-2
+
+[role="_abstract"]
+The {ProductShortName} 8.1.2 section lists the issues fixed in this release.
+
+include::topics/release-notes-topics/ref_fixed-issues-8-1-2.adoc[leveloffset=+1]
+
+ifdef::parent-context-of-mta-8-1-2[:context: {parent-context-of-mta-8-1-2}]
+ifndef::parent-context-of-mta-8-1-2[:!context:]
+

--- a/assemblies/release-notes/assembly_mta-8-1.adoc
+++ b/assemblies/release-notes/assembly_mta-8-1.adoc
@@ -17,6 +17,8 @@ endif::[]
 [role="_abstract"]
 This Release Notes section provides high-level coverage of the improvements and additions that have been implemented in {ProductFullName} 8.1.
 
+include::assembly_mta-8-1-2.adoc[leveloffset=+1]
+
 include::assembly_mta-8-1-1.adoc[leveloffset=+1]
 
 include::assembly_mta-8-1-0.adoc[leveloffset=+1]

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-1-2.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-1-2.adoc
@@ -1,0 +1,17 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-05-06
+:_mod-docs-content-type: REFERENCE
+
+[id="fixed-issues-8-1-2_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+{ProductFirstRef} ({ProductShortName}) version 8.1.2 provides the following fixed issues that have a significant impact.
+
+////
+placeholder for MTA-6898
+
++
+(link:https://redhat.atlassian.net/browse/MTA-6898[MTA-6898])
+
+////

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-1-2.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-1-2.adoc
@@ -8,10 +8,8 @@
 [role="_abstract"]
 {ProductFirstRef} ({ProductShortName}) version 8.1.2 provides the following fixed issues that have a significant impact.
 
-////
-placeholder for MTA-6898
-
+The C# analyzer accurately calculates code snippet boundaries::
+Before this update, when analyzing C# applications, the {ProductFullName} incorrectly calculated the boundaries for code snippets when rule violations occurred further down in a source file. As a consequence, the `codesnip` section in the analysis output cut off right before the violation, failing to display the actual line of code causing the issue. With this update, the C# analyzer provider properly calculates the code snippet boundaries to include the affected lines. As a result, the generated code snippets in the analysis output correctly display the exact violation line numbers and their full context.
 +
 (link:https://redhat.atlassian.net/browse/MTA-6898[MTA-6898])
 
-////

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -27,14 +27,14 @@ ifdef::mta[]
 :WebNameTitle: User Interface
 :WebNameURL: user_interface_guide
 :WebConsoleBookName: {WebNameTitle} Guide
-:ProductVersion: 8.1.1
+:ProductVersion: 8.1.2
 :PluginName: MTA plugin
 :mta-dl-full: Red Hat Developer Lightspeed for migration toolkit for applications
 :mta-dl-plugin: Red Hat Developer Lightspeed for MTA
 :mta-URL: https://docs.redhat.com/en/documentation/migration_toolkit_for_applications/{DocInfoProductNumber}/html-single
 
-:ProductDistributionVersion: 8.1.1.GA-redhat
-:ProductDistribution: mta-8.1.1.GA-cli-offline.zip
+:ProductDistributionVersion: 8.1.2.GA-redhat
+:ProductDistribution: mta-8.1.2.GA-cli-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download
 :JiraWindupURL: https://issues.redhat.com/projects/MTA/issues
 // OpenShift


### PR DESCRIPTION
Tracked under:

- Release notes: https://redhat.atlassian.net/browse/MTA-6787
- Attributes: https://redhat.atlassian.net/browse/MTA-6786

Preview: https://mpershina.github.io/Previews/MTA/8.1.2-RNs.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 8.1.2 and included them in the 8.1 release notes.
  * Added a "Fixed issues" entry for 8.1.2 with a referenced issue.
  * Updated product version and distribution attributes to 8.1.2.
  * Introduced optional contextual scaffolding for release-note rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->