### PR TITLE
[MTA-6933] Visual Studio Code MTA plugin installation options

### DIFF
--- a/docs/topics/vscode/proc_installing-vscode-extension.adoc
+++ b/docs/topics/vscode/proc_installing-vscode-extension.adoc
@@ -3,7 +3,21 @@
 = Installing the {ProductShortName} extension for Visual Studio Code
 
 [role="_abstract"]
-You can use the {ProductFullName} Visual Studio Code plugin to perform a standard application analysis. You can also enable Red Hat Developer Lightspeed for the {ProductName} to use Generative AI (GenAI) capabilities to fix code issues before migrating to target technologies. Note that Developer Lightspeed for {ProductShortName} is enabled by default. For more information, see link:{mta-URL}/configuring_and_using_red_hat_developer_lightspeed_for_mta/index[Configuring and using Developer Lightspeed for {ProductShortName}].
+Install the {ProductFullName} extension pack or the {ProductShortName} Core extension with a language-specific extension to perform an application analysis. Use the extension pack to analyze in all supported languages or the Core and a language-specific plugin to optimize the memory usage.
+
+You can install the following language-specific {ProductShortName} Visual Studio Code extensions from the Visual Studio Code Marketplace:
+
+* `Java`
+* `JavaScript` to analyze `JavaScript` and `Node.js` applications
+* `C#` to analyze `C#` and `.NET` applications
+* `Go`
+
+:FeatureName: `Extension pack`, `C#`, `JavaScript`, and `Go` extensions
+[IMPORTANT]
+====
+{FeatureName} are Developer Preview features only. Developer Preview features are not supported by Red{nbsp}Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features provide early access to upcoming product features in advance of their possible inclusion in a Red{nbsp}Hat product offering, enabling customers to test functionality and provide feedback during the development process. These features might not have any documentation, are subject to change or removal at any time, and testing is limited. Red{nbsp}Hat might provide ways to submit feedback on Developer Preview features without an associated service level agreement (SLA).
+====
+:!FeatureName:
 
 .Prerequisites 
 
@@ -19,4 +33,9 @@ You can use the {ProductFullName} Visual Studio Code plugin to perform a standar
 
 .Procedure
 
-* Install the {ProductShortName} {ProductVersion} Visual Studio Code plugin from the link:https://marketplace.visualstudio.com/search?term=migration%20toolkit&target=VSCode&category=All%20categories&sortBy=Relevance[Visual Studio Code Marketplace]. 
+* Install the {ProductShortName} {ProductVersion} Visual Studio Code plugin from the Visual Studio Code Marketplace.
+
+.Additional resources
+* link:https://marketplace.visualstudio.com/search?term=migration%20toolkit&target=VSCode&category=All%20categories&sortBy=Relevance[Visual Studio Code Marketplace]
+* link:{mta-URL}/configuring_and_using_red_hat_developer_lightspeed_for_mta/index[Configuring and using Developer Lightspeed for {ProductShortName}]
+* link:https://access.redhat.com/support/offerings/devpreview[Developer Preview Support Scope]


### PR DESCRIPTION
### Version

* 8.1.1

### JIRA

* https://redhat.atlassian.net/browse/MTA-6933

### Preview
* [2. Installing the MTA extension for Visual Studio Code](https://pkylas007.github.io/Preview/MTA/mta-vs-code-installations/index.html#installing-vscode-extension_vsc-extension-guide)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote VS Code extension installation guidance to present two install options: full extension pack or core + language-specific extensions for lower memory usage
  * Listed supported language extensions (Java, JavaScript/Node.js, C#, Go) and added a “Developer Preview features only” warning
  * Removed prior Lightspeed enablement note and moved Marketplace, configuration, and support links into an “Additional resources” section

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/mta-documentation/pull/365)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->