### PR TITLE
Vale update 19th May

### DIFF
--- a/.github/styles/RedHat/Abbreviations.yml
+++ b/.github/styles/RedHat/Abbreviations.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 level: error
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/abbreviations/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#abbreviations
 message: "Do not use periods in all-uppercase abbreviations such as '%s'."
 nonword: true
 # source: "IBM - Periods with abbreviations, p. 5"

--- a/.github/styles/RedHat/CaseSensitiveTerms.yml
+++ b/.github/styles/RedHat/CaseSensitiveTerms.yml
@@ -2,7 +2,7 @@
 extends: substitution
 ignorecase: false
 level: warning
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/casesensitiveterms/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#case-sensitive-terms
 message: "Use '%s' rather than '%s'."
 action:
   name: replace
@@ -11,6 +11,7 @@ swap:
   "(?<!/)var": VAR
   "(?<!Business )Resource Planner|(?<!Business Resource )Planner": Business Resource Planner
   "(?<!Microsoft Azure )On-Demand Marketplace": Microsoft Azure On-Demand Marketplace
+  "(?<!Red Hat )Advanced Cluster Management|(?<!Red Hat )Advanced Cluster Management for Kubernetes|ACM|ACMK": Red Hat Advanced Cluster Management for Kubernetes
   "(?<!Red Hat )JBoss Enterprise Application Platform": Red Hat JBoss Enterprise Application Platform
   "(?<!Red Hat )OpenStack Platform|RHOS|RH-OSP": Red Hat OpenStack Platform
   "(?<!Red Hat JBoss )BRMS(?! engine)": inference engine
@@ -20,7 +21,7 @@ swap:
   "[dD]ay-1|day 1": Day 1
   "[dD]ay-2|day 2": Day 2
   "BPMS|(?<!Red Hat )JBoss BPMS|(?<!Red Hat JBoss )BPM(?! Suite)": Red Hat JBoss BPM Suite
-  "DM(?![ -]Multipath)|directory manager": Directory Manager
+  "DM(?![ -]?[Mm]ultipath)|directory manager": Directory Manager
   "JBoss Broker|Red Hat Broker|The AMQ Broker": AMQ Broker
   "JBoss Console|Red Hat Console": AMQ Console
   "Kernel(?!-based Virtual Machine| Module Management| parameters| arguments| packet filtering)": kernel
@@ -32,7 +33,7 @@ swap:
   '(?<!JBoss )EAP|(?<!Red Hat )JBoss(?!\sCommunity|\sBroker|\sClients|\sConsole|\sAMQ|\sData\sGrid|\sBRMS|\sBPMS|\sEnterprise\sApplication\sPlatform|\.org|\sInterconnect|\sEAP|\sBPM\sSuite)': JBoss EAP
   '(?<!Realtime )Decision\sServer': Realtime Decision Server
   '[nN]odejs|[nN]ode\.JS|node\.js': Node.js
-  'dotNet': .NET
+  '\b(NVidia|N-Vidia|Nvidia|nVIDIA|nvidia[^\/])\b': NVIDIA
   'A-MQ(?!\sBroker|\sClient|\sConsole|\sInterconnect)': AMQ
   'A-MQ\sBroker': AMQ Broker
   'A-MQ\sClients': AMQ Clients
@@ -42,6 +43,7 @@ swap:
   'ActiveMQ\sArtemis|ActiveMQ(?!\sArtemis)': built-in messaging|JBoss EAP built-in messaging|JBoss EAP messaging
   'Admin\sPortal|webadmin\sportal|webadmin|Administrator\sPortal|Administration\sportal': Administration Portal
   'BRMS\sengine': inference engine
+  'dotNet|dotnet': .NET
   'GUI\seditor|Business\sCentral\seditor': guided editor
   'JBoss\.org': JBoss Community
   'JBoss\sAMQ': AMQ
@@ -54,6 +56,7 @@ swap:
   'RHVM|RHV-M|RHV\sManager': Red Hat Virtualization Manager
   'self-hosted\sengine\svirtual\smachine|engine\sVM': Manager virtual machine
   (?<!Ansible )Playbook: playbook
+  ansible: Ansible
   Ansible playbook: Ansible Playbook
   Ansible rulebook: Ansible Rulebook
   Appliance Console: Appliance console
@@ -75,6 +78,7 @@ swap:
   Capsule server: Capsule Server
   CD 1: "CD #1"
   CDS|Cds: CDs
+  ceph(?!fs|-): Ceph
   Ceph Ansible: ceph-ansible
   Ceph block device|Ceph block devices: Ceph Block Device
   Ceph filesystem|Ceph file system: Ceph File System
@@ -84,6 +88,7 @@ swap:
   cephfs: CephFS
   CGroup|c group: cgroup
   cidr|Classless Interdomain Routing|Classless Inter-domain Routing: CIDR
+  Classloader: class loader
   classic mode: GNOME Classic
   CloudForms Management Engine|CFME: Red Hat CloudForms|Red Hat CloudForms Appliance
   command prompt: shell prompt|Command Prompt (Windows product)
@@ -116,6 +121,7 @@ swap:
   Faq|faq|F.A.Q: FAQ
   fault tolerant: fault-tolerant
   fault-tolerance: fault tolerance
+  fbc|Fbc|FBC: file-based catalog
   fedora project: Fedora™ Project
   filestore|File Store: FileStore
   Firewalld|firewallD|FirewallD: firewalld
@@ -157,6 +163,8 @@ swap:
   ipv4|IPV4|Ipv4: IPv4
   ipv6|IPV6|Ipv6: IPv6
   iSeries: ISeries
+  Intellij(?! IDEA): IntelliJ
+  Intellij IDEA: IntelliJ IDEA
   iso: ISO
   Istio Service Mesh: Istio service mesh
   Itanium2: Itanium 2
@@ -167,8 +175,9 @@ swap:
   jetbrains|Jetbrains: JetBrains
   Junit|junit: JUnit
   Jvm|jvm: JVM
-  kbase|knowledge base: KIE base
+  kbase: KIE base
   kernel-based virtual machine: Kernel-based Virtual Machine
+  kibana: Kibana
   kernelspace: kernel space
   key store: keystore
   kickstart: Kickstart
@@ -182,6 +191,7 @@ swap:
   Lan|lan: LAN
   Librados|LIBRADOS: librados
   Librbd|LIBRBD: librbd
+  Lightspeed|LightSpeed: Red Hat Ansible Lightspeed|Red Hat Enterprise Linux Lightspeed
   Lightweight Directory Access Protocol over Secure Socket Layer: LDAPS
   LINUX|linux: Linux
   live-backup group: master-slave group
@@ -198,18 +208,22 @@ swap:
   MS-dos|Ms-Dos|ms-dos|MSDOS|msdos: MS-DOS
   MTLS|m-TLS: mTLS
   mutual tls|Mutual tls|Mutual TLS: mutual TLS
-  MYSQL|mySQL: MySQL
+  MYSQL|mySQL|Mysql|mysql: MySQL
   native interface: management CLI
   network interface card: network interface controller (NIC)
   objectclass: objectClass
   Objective-C: Objective C
+  Oauth: OAuth
+  oci|Oci: OCI
   OCP: Red Hat OpenShift Container Platform
   ODF: Red Hat OpenShift Data Foundation
   OK button|okay|ok: OK
+  open container initiative|Open container initiative: Open Container Initiative
   Open InfiniBand|Infiniband: InfiniBand
   Open Telemetry: OpenTelemetry (OTel)
   openid connect|Openid Connect: OpenID Connect
   openrewrite|Openrewrite|Open Rewrite: OpenRewrite
+  Openshift(?! online| Kubernetes| Origin): OpenShift
   Openshift online|OO: Red Hat OpenShift Online
   Operating Environment: operating environment
   Operator Hub|Operator hub|Operatorhub|operatorhub: OperatorHub
@@ -219,10 +233,12 @@ swap:
   OS|Operating System: operating system
   Overcloud: overcloud
   P-PC|PPC64: PowerPC
+  php: PHP
   Podman desktop: Podman Desktop
   podman: Podman
   popup|Pop-up: pop-up
   Posix|posix: POSIX
+  postgres|Postgresql: PostgreSQL
   Postscript: PostScript
   Powershell|powershell: PowerShell
   Ppp|ppp: PPP
@@ -249,7 +265,8 @@ swap:
   Redboot|Red Boot: RedBoot
   RedFish: Redfish
   redis: Redis
-  RESTEASY|resteasy|Resteasy: RESTEasy
+  RESTEASY|(?<!-)resteasy|Resteasy: RESTEasy
+  restic: Restic
   RHDS: Red Hat Directory Server
   RHEL host|RHEL-H: Red Hat Enterprise Linux host
   RHV: Red Hat Virtualization
@@ -263,6 +280,7 @@ swap:
   s-record|S-Record|s-Record|SREC: S-record
   samba|SAMBA: Samba
   Satellite server: Satellite Server
+  Sbt: sbt
   SE-Linux|S-E Linux|SE Linux|selinux: SELinux
   Shadow Man|ShadowMan: Shadowman
   Shadow passwords: shadow passwords
@@ -280,7 +298,6 @@ swap:
   SR IOV: SR-IOV
   Ssh|ssh: SSH
   SSL handshake: TLS handshake
-  SSL(?!/TLS): SSL/TLS
   standard Manager|standard environment: standalone Manager
   Staroffice|Star Office: StarOffice
   StartTLS|startTLS: STARTTLS
@@ -296,9 +313,10 @@ swap:
   ttl: TTL
   uid: UID
   ULTRASPARC|UltraSparc: UltraSPARC
-  Unix|unix|UNIX-like: UNIX
+  Unix|unix: UNIX
   uri: URI
   url: URL
+  velero: Velero
   urn: URN
   VCPU|vcpu: vCPU
   VI: vi
@@ -307,6 +325,7 @@ swap:
   virtual-console|Virtual Console: virtual console
   vlan|vLAN: VLAN
   VM portal|vm portal|Virtual Machine Portal|User Portal: VM Portal
+  VMWare: VMware
   vnic|VNIC|Virtual Network Interface Card: vNIC
   vnuma|VNUMA: vNUMA node
   vpn: VPN

--- a/.github/styles/RedHat/Conjunctions.yml
+++ b/.github/styles/RedHat/Conjunctions.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/conjunctions/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#conjunctions
 message: "Do not overuse beginning sentences with '%s'."
 scope: paragraph
 # source: https://github.com/redhat-documentation/vale-at-red-hat/tree/main/.vale/styles/RedHat/Conjunctions.yml
@@ -11,4 +11,4 @@ tokens:
   - ^And
   - ^But
   - ^Or
-  - ^So
+  - ^So(?! that)

--- a/.github/styles/RedHat/ConsciousLanguage.yml
+++ b/.github/styles/RedHat/ConsciousLanguage.yml
@@ -2,12 +2,12 @@
 extends: substitution
 ignorecase: true
 level: warning
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/consciouslanguage/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#conscious-language
 message: "Use %s rather than '%s'."
 action:
   name: replace
 swap:
   blacklist: blocklist
-  master(?! broker): primary|source|initiator|requester|controller|host|director|supplier
+  master(?! broker| boot record): primary|source|initiator|requester|controller|host|director|supplier
   slave(?! broker): secondary|replica|responder|device|worker|proxy|performer|consumer|child
   whitelist: allowlist

--- a/.github/styles/RedHat/Contractions.yml
+++ b/.github/styles/RedHat/Contractions.yml
@@ -2,7 +2,7 @@
 extends: substitution
 ignorecase: true
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/contractions/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#contractions
 message: "Avoid contractions. Use '%s' rather than '%s.'"
 # source: "https://redhat-documentation.github.io/supplementary-style-guide/#contractions"
 action:

--- a/.github/styles/RedHat/Definitions.yml
+++ b/.github/styles/RedHat/Definitions.yml
@@ -2,7 +2,7 @@
 extends: conditional
 ignorecase: false
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/definitions/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#definitions
 message: "Define acronyms and abbreviations (such as '%s') on first occurrence if they're likely to be unfamiliar."
 # source: "IBM - Abbreviations, p. 1"
 # Ensures that the existence of 'first' implies the existence of 'second'.
@@ -15,29 +15,46 @@ exceptions:
   - 'CVEs?'
   - 'DVDs?'
   - 'GIDs?'
+  - 'GPUs?'
+  - 'LLMs?'
   - 'NULL'
   - 'PIDs?'
+  - 'PVCs?'
   - 'ROMs?'
   - 'RPMs?'
+  - 'SDKs?'
+  - 'SRPMs?'
   - 'UIDs?'
   - 'URIs?'
   - 'URLs?'
+  - AAP
   - ACPI
+  - ADR
+  - AIDC
   - AIX
+  - ALPN
+  - AMQP
   - ARM
   - ASCII
   - ASP
+  - AWQ
   - AWS
   - BIND
   - BIOS
   - BMC
+  - BSL
   - CD
+  - CDI
   - CIDR
   - CLI
   - CNAME
+  - CRI
+  - CSI
   - CSS
   - CSV
+  - CUDA
   - CUPS
+  - DCGM
   - DEBUG
   - DHCP
   - DNF
@@ -60,14 +77,16 @@ exceptions:
   - GCJ
   - GDB
   - GET
+  - GGUF
   - GIF
   - GIMP
   - GNOME
   - GNU
   - GNUPro
   - GPL
-  - GPU
+  - GPTQ
   - GRUB
+  - GSAI
   - GTK+
   - GUI
   - GUID
@@ -78,40 +97,64 @@ exceptions:
   - IAM
   - IBM
   - IDE
+  - IEEE
   - IOPS
   - IOV
   - IP
   - ISO
   - IT
   - JAR
+  - JAXB
+  - JDBC
+  - JIB
+  - JMS
+  - JNLP
+  - JPA
   - JPEG
   - JSON
   - JSX
+  - JTA
   - JVM
+  - JWT
   - KB
   - KIE
   - KVM
   - LAN
   - LDAP
+  - LDIF
   - LESS
+  - LGAI
   - LLDB
   - LPAR
+  - LTS
   - LUKS
   - LVM
   - MAC
   - MB
   - MBR
   - MDS
+  - MLP
+  - MLX
+  - MQTT
   - mTLS
+  - MUST
+  - NABSL
   - NAT
   - NET
   - NFS
   - NGINX
   - NIC
+  - NLP
+  - NOT
   - NOTE
   - NTP
   - NVDA
+  - OADP
+  - OCI
   - OEM
+  - OIDC
+  - OLM
+  - ORM
   - OSS
   - OVN
   - OVS
@@ -125,6 +168,7 @@ exceptions:
   - POST
   - PPP
   - PROM
+  - PTO
   - PTP
   - PV
   - PVC
@@ -142,22 +186,31 @@ exceptions:
   - RFC
   - RGW
   - RHEL
+  - RHOAS
+  - RHSSO
+  - ROSA
   - RSA
   - SAML
   - SAP
+  - SCC
   - SCM
   - SCSI
   - SCSS
   - SDK
+  - SEED
   - SFTP
   - SHA
+  - SMTP
   - SOCKS
   - SPEC
   - SQL
   - SSD
   - SSH
   - SSL
+  - SSO
   - SSSD
+  - STM
+  - STS
   - SVG
   - SVN
   - SWAT
@@ -182,10 +235,12 @@ exceptions:
   - VPN
   - WAN
   - WCA
+  - WIPO
   - XFS
   - XML
   - XSS
   - YAML
   - YUM
+  - YYYY
   - ZIP
   - ZTP

--- a/.github/styles/RedHat/DoNotUseTerms.yml
+++ b/.github/styles/RedHat/DoNotUseTerms.yml
@@ -2,12 +2,12 @@
 extends: substitution
 ignorecase: false
 level: warning
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/donotuseterms/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#do-not-use-terms
 message: "%s"
 swap:
   # Start each error message with "Do not use ..."
   # Error messages must be single quoted.
-  'ACK(?! flag)': 'Do not use "ACK" as acronym for "acknowledgement". When writing about the acknowledgement flag ("ACK flag") in a TCP packet, use "ACK flag".'
+  'ACK(?! flag| packet)': 'Do not use "ACK" as acronym for "acknowledgement". When writing about the acknowledgement flag ("ACK flag") or acknowledgement packet ("ACK packet") in a TCP packet, use "ACK flag" or "ACK packet".'
   'future-proof': Do not use "future-proof" in a statement about the benefits, characteristics, or performance of a Red Hat product or service.'
   'out of the box|out-of-the-box': 'Do not use "out of the box" or "out-of-the-box". Use text that is suitable for the context and the noun to which this adjective applies.'
   and/or: 'Do not use "and/or". Depending on the context, use one of the following constructions: a and b, a or b, or a, b, or both.'

--- a/.github/styles/RedHat/Ellipses.yml
+++ b/.github/styles/RedHat/Ellipses.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/ellipses/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#ellipses
 message: "Avoid the ellipsis (...) except to indicate omitted words."
 nonword: true
 # source: "IBM - Ellipses, p.49"

--- a/.github/styles/RedHat/EmDash.yml
+++ b/.github/styles/RedHat/EmDash.yml
@@ -4,7 +4,7 @@ ignorecase: true
 level: warning
 scope: raw
 nonword: true
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/emdash/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#em-dash
 message: Do not use em dashes. Use punctuation marks such as commas, parentheses, or colons instead.
 tokens:
   - '—'

--- a/.github/styles/RedHat/GitLinks.yml
+++ b/.github/styles/RedHat/GitLinks.yml
@@ -1,7 +1,6 @@
 ---
 extends: existence
 message: Do not include a link to %s unless it is explicitly approved.
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/gitlinks/
 ignorecase: true
 nonword: true
 level: warning
@@ -9,5 +8,5 @@ scope: raw
 action:
   name: remove
 tokens:
-  - 'https:\/\/gitlab\.com\/\w+'
-  - 'https:\/\/github\.com(?!\/openshift|\/redhat-developer)'
+  - 'https:\/\/gitlab\.com(?!\/redhat)\/\w+'
+  - 'https:\/\/github\.com(?!\/openshift|\/redhat-developer|\/redhat-documentation|\/quarkusio)'

--- a/.github/styles/RedHat/HeadingPunctuation.yml
+++ b/.github/styles/RedHat/HeadingPunctuation.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 level: warning
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/headingpunctuation/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#heading-punctuation
 message: "Do not use end punctuation in headings."
 nonword: true
 scope: heading

--- a/.github/styles/RedHat/Headings.yml
+++ b/.github/styles/RedHat/Headings.yml
@@ -1,7 +1,7 @@
 ---
 extends: capitalization
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/headings/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#headings
 match: $sentence
 message: "Use sentence-style capitalization in '%s'."
 scope: heading
@@ -44,6 +44,7 @@ exceptions:
   - Civetweb
   - ClassLoader
   - Classloader
+  - Cloud Credential Operator
   - Cloudbursting
   - Cloudwashing
   - CodeReady
@@ -58,6 +59,7 @@ exceptions:
   - DNS
   - DaemonSet
   - Datadog
+  - DeploymentConfig
   - Dev
   - DevOps
   - DevWorkspace
@@ -131,6 +133,7 @@ exceptions:
   - Jave
   - JetBrains
   - Jira
+  - JobSet
   - Jolokia
   - Joyent
   - Kibana
@@ -142,6 +145,7 @@ exceptions:
   - Kubespray
   - Kylin
   - Laravel
+  - Linux
   - Liquibase
   - Logstash
   - Lombok
@@ -159,6 +163,7 @@ exceptions:
   - MongoDB
   - MySQL
   - Nagios
+  - NVIDIA
   - Narayana
   - Neoverse
   - NetcoredebugOutput
@@ -168,8 +173,10 @@ exceptions:
   - Node.js
   - NuGet
   - OAuth
+  - OCI
   - ORM
   - OmniSharp
+  - Open Container Initiative
   - OpEx
   - OpenID Connect
   - OpenJDK
@@ -195,14 +202,23 @@ exceptions:
   - Quarkus
   - Quiltflower
   - Qute
+  - RamaLama
   - RESTEasy
   - Red Hat
+  - Red Hat Advanced Cluster Management
+  - Red Hat Advanced Cluster Management for Kubernetes
+  - Red Hat Ansible Lightspeed
+  - Red Hat Enterprise Linux Lightspeed
+  - Red Hat Marketplace
+  - Red Hat OpenShift Cluster Manager
   - RedBoot
   - Redis
   - Redistributions
+  - Ruby on Rails
   - SCM
   - SDK
   - SELinux
+  - Service Binding Operator
   - SVG
   - Sakila
   - Semeru
@@ -249,6 +265,7 @@ exceptions:
   - Yeoman
   - Zowe
   - cgroup
+  - macOS
   - eServer
   - gRPC
   - mutual TLS
@@ -259,3 +276,14 @@ exceptions:
   - vNUMA
   - xDS
   - xterm
+  - Ansible Galaxy
+  - Ansible Tower
+  - Automation Controller
+  - Automation Hub
+  - Automation Mesh
+  - Automation Services Catalog
+  - Event-Driven Ansible
+  - Keycloak
+  - Private Automation Hub
+  - Receptor
+  - Red Hat Ansible Automation Platform

--- a/.github/styles/RedHat/Hyphens.yml
+++ b/.github/styles/RedHat/Hyphens.yml
@@ -2,7 +2,7 @@
 extends: substitution
 ignorecase: true
 level: warning
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/hyphens/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#hyphens
 message: "Use %s rather than '%s'."
 action:
   name: replace
@@ -188,7 +188,7 @@ swap:
   pseudo-code: pseudocode
   pseudo-random: pseudorandom
   pseudo-text: pseudotext
-  pulldown|pull down: pull-down
+  pulldown: pull-down
   re-direct: redirect
   re-edit: reedit
   re-examine: reexamine

--- a/.github/styles/RedHat/MergeConflictMarkers.yml
+++ b/.github/styles/RedHat/MergeConflictMarkers.yml
@@ -3,7 +3,7 @@ extends: existence
 scope: raw
 level: error
 nonword: true
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/mergeconflictmarkers/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#merge-conflict-markers
 message: "Do not commit Git merge conflict markers in source code."
 action:
   name: remove

--- a/.github/styles/RedHat/ObviousTerms.yml
+++ b/.github/styles/RedHat/ObviousTerms.yml
@@ -8,9 +8,9 @@ scope: sentence
 action:
   name: remove
 tokens:
+  - 'Description field'
+  - 'Mail field'
+  - 'Name field'
+  - 'Password field'
   - 'User field'
   - 'Username field'
-  - 'Password field'
-  - 'Mail field'
-  - 'Description field'
-  - 'Name field'

--- a/.github/styles/RedHat/OxfordComma.yml
+++ b/.github/styles/RedHat/OxfordComma.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/oxfordcomma/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#oxford-comma
 message: "Use the Oxford comma in '%s'."
 scope: sentence
 nonword: true

--- a/.github/styles/RedHat/PascalCamelCase.yml
+++ b/.github/styles/RedHat/PascalCamelCase.yml
@@ -18,9 +18,11 @@ exceptions:
   - 'vCPUs?'
   - 3scale
   - AGPLv
+  - AirPrint
   - AMQ
   - API
   - AppStream
+  - ArgoCD
   - AsciiDoc
   - AssertJ
   - BaseOS
@@ -34,23 +36,36 @@ exceptions:
   - CheckTree
   - ClassLoader
   - CloudForms
+  - CloudTrail
+  - CloudWatch
+  - CodeLlama
   - CodeReady
   - ConfigMaps?
   - ConnectX
   - Convert2RHEL
   - CoreOS
+  - CPUfreq
   - DaemonSet
+  - DataMover
   - DDoS
+  - DeepSeek
   - DevOps
   - DevWorkspace
+  - DialoGPT
   - DNSSec
+  - DoS
+  - DoT
+  - EleutherAI
   - eServer
   - eXpress
   - eXtenSion
   - FaaS
   - FCoE
+  - FFmpeg
   - FileStore
   - FireWire
+  - FreeIPA
+  - FreeOTP
   - FreeRADIUS
   - GbE
   - GBps
@@ -64,14 +79,17 @@ exceptions:
   - GraalVM
   - GraphQL
   - GTID
+  - HAProxy
   - HashBase
   - HdrHistogram
   - Helm
+  - HyperCLOVAX
   - HyperShift
   - IaaS
   - IBoE
   - IconBurst
   - IdM
+  - IdPs?
   - IKEv
   - InfiniBand
   - InnoDB
@@ -81,12 +99,14 @@ exceptions:
   - IPsec
   - IPv
   - ISeries
+  - JackFram
   - JavaScript
   - JBoss
   - JetBrains
   - JUnit
   - kBps
   - KiB
+  - KTLim
   - LangTags
   - LGPLv
   - libOSMesa
@@ -95,31 +115,44 @@ exceptions:
   - LightPulse
   - LinuxONE
   - LiquidIO
+  - LLaDA
+  - MACSec
   - ManageIQ
   - MariaDB
+  - MaziyarPanahi
   - MBps
   - MegaRAID
   - MiB
   - MicroProfile
+  - ModSecurity
+  - MinIO
+  - MoE
   - MongoDB
   - MoreUtils
   - MySQL
   - NetBIOS
   - NetcoredebugOutput
   - NetWeaver
+  - NetKVM
   - NetworkManager
   - NetXen
   - NetXtreme
   - NFSv
   - NMState
+  - NoCloud
+  - NodeJS
+  - NooBaa
+  - NousResearch
+  - NTAuth
   - NuGet
-  - NVidia
   - NVMe
   - OAuth
   - objectClass
   - OmniSharp
   - OneConnect
+  - OpenELM
   - OpenEXR
+  - OpenHermes
   - OpenID
   - OpenIPMI
   - OpenJDK
@@ -135,6 +168,9 @@ exceptions:
   - OperatorHub
   - OpEx
   - OSBuild
+  - OSTree
+  - OSToy
+  - OStoy
   - OTel
   - PaaS
   - PackageKit
@@ -145,6 +181,7 @@ exceptions:
   - PostScript
   - PowerPC
   - PowerShell
+  - PowerTOP
   - ProLiant
   - PulseAudio
   - PyPA
@@ -156,31 +193,39 @@ exceptions:
   - RESTEasy
   - RHEL
   - RoCE
+  - RubyGems
   - SaaS
   - SeaBIOS
   - SELinux
   - SmallRye
   - SmartNIC
   - SmartState
+  - SmolLM
   - SQLite
   - StarOffice
   - STMicroelectronics
   - SuperLU
   - SysV
+  - SystemTap
   - TBps
+  - TheBloke
   - TiB
+  - TinyLlama
   - TuneD
   - TypeScript
   - UltraSPARC
   - USBGuard
   - vCenter
   - vDisk
+  - vGPUs?
   - vHost
   - VMware
   - vSphere
   - vSwitch
+  - vLLM
   - WebAuthn
   - WebSocket
+  - WebUI
   - WireGuard
   - XEmacs
   - xPaaS
@@ -188,3 +233,5 @@ exceptions:
   - XWayland
   - YouTube
   - ZCentral
+  - JavaDoc
+  - StackOverflow

--- a/.github/styles/RedHat/PassiveVoice.yml
+++ b/.github/styles/RedHat/PassiveVoice.yml
@@ -2,7 +2,7 @@
 extends: existence
 ignorecase: true
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/passivevoice/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#passive-voice
 message: "'%s' is passive voice. In general, use active voice. Consult the style guide for acceptable use of passive voice."
 # source: "https://redhat-documentation.github.io/supplementary-style-guide/#prerequisites; IBM - Voice, p.35"
 raw:
@@ -188,6 +188,7 @@ exceptions:
   - deprecated
   - displayed
   - imported
+  - interested
   - supported
   - tested
   - trusted

--- a/.github/styles/RedHat/ProductCentricWriting.yml
+++ b/.github/styles/RedHat/ProductCentricWriting.yml
@@ -2,7 +2,7 @@
 extends: existence
 ignorecase: true
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/productcentricwriting/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#product-centric-writing
 message: "Do not use transitive verb constructions like '%s' to grant abilities to inanimate objects. Whenever possible, use direct, user-focused sentences where the subject of the sentence performs the action."
 tokens:
   - '(allows?|enables?|lets?|permits?)\s(you|customers|the customer|the user|users)'

--- a/.github/styles/RedHat/ReadabilityGrade.yml
+++ b/.github/styles/RedHat/ReadabilityGrade.yml
@@ -2,7 +2,7 @@
 extends: readability
 grade: 9
 message: "Simplify your language. The calculated Flesch–Kincaid grade level of %s is above the recommended reading grade level of 9."
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/readabilitygrade/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#readability-grade
 level: suggestion
 metrics:
   - Flesch-Kincaid

--- a/.github/styles/RedHat/ReleaseNotes.yml
+++ b/.github/styles/RedHat/ReleaseNotes.yml
@@ -2,7 +2,7 @@
 extends: substitution
 ignorecase: false
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/releasenotes/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#release-notes
 message: "For release notes, consider using '%s' rather than '%s'."
 # source: "https://redhat-documentation.github.io/supplementary-style-guide/#release-notes"
 # swap maps tokens in form of bad: good

--- a/.github/styles/RedHat/RepeatedWords.yml
+++ b/.github/styles/RedHat/RepeatedWords.yml
@@ -2,7 +2,7 @@
 extends: repetition
 message: "'%s' is repeated."
 level: warning
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/repeatedwords/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#repeated-words
 ignorecase: false
 alpha: true
 action:

--- a/.github/styles/RedHat/SelfReferentialText.yml
+++ b/.github/styles/RedHat/SelfReferentialText.yml
@@ -2,7 +2,7 @@
 extends: existence
 ignorecase: true
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/selfreferentialtext/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#self-referential-text
 message: "Avoid using self-referential text such as '%s'."
 # source: "IBM - Audience and medium, p. 22"
 tokens:

--- a/.github/styles/RedHat/SentenceLength.yml
+++ b/.github/styles/RedHat/SentenceLength.yml
@@ -1,7 +1,7 @@
 ---
 extends: occurrence
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/sentencelength/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#sentence-length
 message: "Try to keep sentences to an average of 32 words or fewer."
 scope: sentence
 # source: "IBM - Conversational style"

--- a/.github/styles/RedHat/SimpleWords.yml
+++ b/.github/styles/RedHat/SimpleWords.yml
@@ -2,12 +2,11 @@
 extends: substitution
 ignorecase: true
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/simplewords/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#simple-words
 message: "Use simple language. Consider using '%s' rather than '%s'."
 action:
   name: replace
 swap:
-  "(?<!an |the |IP |IPv[46] |MAC |sub-)address": discuss
   "approximate(?:ly)?": about
   "objective(?! C?)": aim|goal
   absent: none|not here
@@ -48,7 +47,6 @@ swap:
   collaborate: work together
   commence: begin
   compensate: pay
-  component: part
   comprise: form|include
   concerning: about
   confer: give|award
@@ -91,7 +89,6 @@ swap:
   maintain: keep|support
   methodology: method
   modify: change
-  monitor: check|watch
   multiple: many
   necessitate: cause
   notify: tell
@@ -113,7 +110,6 @@ swap:
   subsequent: later|next
   substantial: large
   sufficient: enough
-  terminate: end
   transmit: send
   utilization: use
   utilize: use

--- a/.github/styles/RedHat/Slash.yml
+++ b/.github/styles/RedHat/Slash.yml
@@ -1,27 +1,125 @@
----
 extends: existence
 ignorecase: true
 level: warning
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/slash/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#slash
 message: "Use either 'or' or 'and' in '%s'"
-# source: "IBM - Slashes, p. 68"
 scope:
   - sentence
   - heading
 tokens:
   - '(?<!/)\w+/\w+'
 exceptions:
-  - '\d{1,4}\/\d{1,4}'
+  # numbers/dates
+  - '\d{1,4}/\d{1,4}'
+  # URLs and schemes
+  - 'https?://\S+'
+  # common technical terms
   - "0/"
+  - "[Aa]ccess/InfiniBand"
+  - "[Aa]ctive/[Aa]ctive"
+  - "[Aa]ctive/[Pp]assive"
+  - "[Cc]heckpoint/[Rr]estore"
+  - "[Gg]roup/[Vv]ersion"
   - "[Ii]nput/[Oo]utput"
+  - "[Kk]ey/value"
+  - "[Mm]in/[Mm]ax"
+  - "[Pp]acemaker/[Cc]orosync"
+  - "[Pp]ublish/[Ss]ubscribe"
+  - "[Ss]ource/[Dd]estination"
+  - "[Ss]top/[Ss]tart"
+  - "A/B"
   - "C/C"
+  - "CI/CD"
   - "client/server"
+  - "HTTP/HTTPS"
   - "I/O"
   - "N/A"
+  - "NVMe/FC"
+  - "NVMe/RDMA"
+  - "NVMe/TCP"
+  - "OS/architecture"
+  - "Q/A"
   - "read/write"
+  - "S/MIME"
   - "SSL/TLS"
+  - "Tcl/T[Kk]"
   - "TCP/IP"
   - "upstream/downstream"
   - "z/OS"
   - "z/OSMF"
-  - "[Kk]ey/value"
+  - "z/VM"
+  - '.*ai/\w+'
+  - '.*AI/\w+'
+  - '.*community/\w+'
+  - '.*EXAONE/\w+'
+  - '.*granite/\w+'
+  - '.*hyperclovax/\w+'
+  - '.*KTLim/\w+'
+  - '.*labs/\w+'
+  - '.*llama/\w+'
+  - '.*ML/\w+'
+  - '.*NLP/\w+'
+  - '.*org/\w+'
+  - '.*quants/\w+'
+  - '.*research/\w+'
+  - '.*spaces/\w+'
+  - '.*t5/\w+'
+  - '.*team/\w+'
+  - '.*testing/\w+'
+  # Kubernetes/OpenShift annotations and registry paths
+  - '\w+\.io/\w+'
+  - 'AIDC-AI/\w+'
+  - 'Alibaba-NLP/\w+'
+  - 'apple/\w+'
+  - 'bartowski/\w+'
+  - 'bigcode/\w+'
+  - 'bigscience/\w+'
+  - 'codellama/\w+'
+  - 'context-labs/\w+'
+  - 'deepseek-ai/\w+'
+  - 'distilbert/\w+'
+  - 'dphn/\w+'
+  - 'EleutherAI/\w+'
+  - 'facebook/\w+'
+  - 'fxmarty/\w+'
+  - 'Gensyn/\w+'
+  - 'ggml-org/\w+'
+  - 'google-t5/\w+'
+  - 'google/\w+'
+  - 'GSAI-ML/\w+'
+  - 'hugging-quants/\w+'
+  - 'HuggingFaceH4/\w+'
+  - 'HuggingFaceM4/\w+'
+  - 'HuggingFaceTB/\w+'
+  - 'ibm-granite/\w+'
+  - 'ibm-research/\w+'
+  - 'JackFram/\w+'
+  - 'kaitchup/\w+'
+  - 'katuni4ka/\w+'
+  - 'kosbu/\w+'
+  - 'LGAI-EXAONE/\w+'
+  - 'liuhaotian/\w+'
+  - 'llamafactory/\w+'
+  - 'lmstudio-community/\w+'
+  - 'lmsys/\w+'
+  - 'MaziyarPanahi/\w+'
+  - 'meta-llama/\w+'
+  - 'microsoft/\w+'
+  - 'mistralai/\w+'
+  - 'MLP-KTLim/\w+'
+  - 'moonshotai/\w+'
+  - 'naver-hyperclovax/\w+'
+  - 'NousResearch/\w+'
+  - 'nvidia/\w+'
+  - 'openai-community/\w+'
+  - 'openai/\w+'
+  - 'openchat/\w+'
+  - 'petals-team/\w+'
+  - 'Qwen/\w+'
+  - 'scb10x/\w+'
+  - 'state-spaces/\w+'
+  - 'teknium/\w+'
+  - 'TheBloke/\w+'
+  - 'TinyLlama/\w+'
+  - 'unsloth/\w+'
+  - 'Vikhrmodels/\w+'

--- a/.github/styles/RedHat/Spacing.yml
+++ b/.github/styles/RedHat/Spacing.yml
@@ -1,7 +1,7 @@
 ---
 extends: existence
 level: error
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/spacing/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#spacing
 message: "Keep one space between words in '%s'."
 nonword: true
 # source: https://docs.microsoft.com/en-us/style-guide/punctuation/periods

--- a/.github/styles/RedHat/Spelling.yml
+++ b/.github/styles/RedHat/Spelling.yml
@@ -36,5 +36,3 @@ filters:
   - '\w+\.\w+'
   # I/O (slash breaks hunspell affix parsing)
   - 'I/O'
-  - '\brulesets?\b'
-  - '\benums?\b'

--- a/.github/styles/RedHat/TermsErrors.yml
+++ b/.github/styles/RedHat/TermsErrors.yml
@@ -90,6 +90,7 @@ swap:
   break point: breakpoint
   bring up: start|power on|open|turn on
   bufferpool: buffer pool
+  builtin: built-in
   busmaster: bus master
   busses: buses
   byte code: bytecode

--- a/.github/styles/RedHat/TermsSuggestions.yml
+++ b/.github/styles/RedHat/TermsSuggestions.yml
@@ -2,23 +2,24 @@
 extends: substitution
 ignorecase: false
 level: suggestion
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termssuggestions/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#terms-suggestions
 message: "Depending on the context, consider using '%s' rather than '%s'."
 scope: sentence
 action:
   name: replace
 swap:
   "(?<!, | in | on | at | to | for | from | of | with | without | against )which": "that|, which"
-  ", that": "that|, which"
   "(?<!.-)jar": compress|archive
+  ", that": "that|, which"
   "[Nn]avigate": click|select|browse|go to
   "bottom(?:-)?left": lower left|lower-left
   "bottom(?:-)?right": lower right|lower-right
-  "shell(?! prompt| script)": shell prompt
+  "shell(?! prompt| script| command)": shell prompt
   "x64|x86-64|(?<!64-bit )x86": 64-bit x86|x86_64
+  '(?<!-|\.)\bk8s\b(?!-|\.)': Kubernetes
   '(?<!.*-|program )operator': Operator
   '(?<!.*-|program )operators': Operators
-  '(?<![\.\-])(?:zip|gzip|tar)(?! file| archive)': compress
+  '(?<![\.\-])(?:zip|gzip|tar)(?! file| archive|\s+[cxtuvf])': compress
   '(?<!\.)tar file': ".tar file"
   '(?<!\.)zip file': ".zip file"
   above: earlier|previous|preceding|before
@@ -31,19 +32,17 @@ swap:
   choose: select
   componentization: component-based development|component model|component architecture|shared components
   componentize: develop components|divide into components|re-engineer into reusable software components
-  consumes: uses
-  distro: distribution
   drag and drop: drag
-  executable(?! program| routine| files?): executable program
+  executable(?! program| routine| files?| code): executable program
   frontend: front end|front-end
-  higher: later
+  higher(?! CPU| latency| level| priority| performance| usage| throughput| bandwidth): later
   hit: press|type
   in order to: to
   information on: information about
   launch: start|open
-  legacy: existing|traditional|established|classic|earlier|previous
-  once: after|when
+  legacy(?! mode| system): existing|traditional|established|classic|earlier|previous
   on-premise: on-site|in-house
+  once: after|when
   refer to: see
   segfault: segmentation fault
   spawn: create
@@ -52,3 +51,4 @@ swap:
   thus: therefore
   translate: convert|transform
   via: through|by|from|on|by using
+  higher version: later version

--- a/.github/styles/RedHat/TermsWarnings.yml
+++ b/.github/styles/RedHat/TermsWarnings.yml
@@ -2,7 +2,7 @@
 extends: substitution
 ignorecase: true
 level: warning
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/termswarnings/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#terms-warnings
 message: "Consider using '%s' rather than '%s' unless updating existing content that uses the term."
 action:
   name: replace
@@ -16,7 +16,6 @@ swap:
   '(?<!\/)etc(?!\/)': and so on
   '\b(?:eg)': for example
   '\b(?:ie)': that is
-  'I(?!/O)': you
   'is updatable|are updatable': can be updated|can be changed
   "(?<!the |the Red Hat )Hybrid Cloud Console|(?<!the )Red Hat Hybrid Cloud Console|(?<!the |Red Hat |Hybrid )Cloud Console|the Cloud Console": the Red Hat Hybrid Cloud Console|the Hybrid Cloud Console
   all caps: uppercase
@@ -42,6 +41,7 @@ swap:
   execute: run|issue|start|enter
   find out: discover
   hamburger|kebab menu|kebab|vertical ellipsis: more options icon|options icon
+  hashbang: shebang|interpreter directive
   he|she: you
   host name: hostname
   illegal: invalid|not allowed|incorrect

--- a/.github/styles/RedHat/UserReplacedValues.yml
+++ b/.github/styles/RedHat/UserReplacedValues.yml
@@ -2,7 +2,7 @@
 extends: existence
 level: suggestion
 message: "Separate words by underscores in user-replaced values."
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/userreplacedvalues/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#user-replaced-values
 scope: raw
 nonword: true
 action:

--- a/.github/styles/RedHat/Using.yml
+++ b/.github/styles/RedHat/Using.yml
@@ -1,8 +1,9 @@
 ---
 extends: sequence
 message: "Use 'by using' instead of 'using' when it follows a noun for clarity and grammatical correctness."
-link: https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/using/
+link: https://redhat-documentation.github.io/vale-at-red-hat/reference-guide.html#using
 level: warning
+scope: ~heading
 action:
   name: edit
   params:
@@ -11,4 +12,4 @@ action:
     - "$1 by using" # replace
 tokens:
   - tag: NN|NNP|NNPS|NNS
-  - pattern: using
+  - pattern: \busing\b

--- a/.github/styles/RedHat/dictionaries/wordlist.txt
+++ b/.github/styles/RedHat/dictionaries/wordlist.txt
@@ -86,7 +86,6 @@ Btrfs
 Bugzilla
 Buildpack
 Buildpacks
-builtin
 Bundler
 Bz
 Bzes
@@ -202,8 +201,6 @@ Emacs
 Emulex
 Endevor
 Entra
-enum
-enums
 Equinix
 Esprima
 Etherchannel
@@ -642,8 +639,6 @@ Rockhopper
 Rollup
 Rubygem
 Rubygems
-ruleset
-rulesets
 SA
 SAs
 SCC


### PR DESCRIPTION
Key Changes:
This PR focuses entirely on updating Vale (an automated linter for prose) to enforce documentation style guidelines. There are 34 files modified in this PR, all of which are located inside the .github/styles/RedHat/ directory.

The changes consist of updates to the Red Hat styling rules and dictionary wordlists, including:

* Grammar & Style Rules: Updates to various YAML configuration files that dictate style rules, such as Abbreviations.yml, ConsciousLanguage.yml, DoNotUseTerms.yml, OxfordComma.yml, PassiveVoice.yml, and RepeatedWords.yml.

* Dictionary Updates: Modifications to .github/styles/RedHat/dictionaries/wordlist.txt to update the accepted/flagged terminology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation style rules and references to align with current Red Hat standards
  * Enhanced recognition and handling of technical terms, product names, and acronyms
  * Refined style rule patterns and exceptions for improved accuracy in documentation validation
  * Updated dictionary entries for improved spelling consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/mta-documentation/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->