### PR TITLE
MTA-6889 CLI refactored commands

### DIFF
--- a/assemblies/cli-guide/assembly_about-the-command-line-tool.adoc
+++ b/assemblies/cli-guide/assembly_about-the-command-line-tool.adoc
@@ -1,0 +1,29 @@
+:_newdoc-version: 2.18.3
+:_template-generated: 2025-06-24
+
+ifdef::context[:parent-context-of-about-the-command-line-tool: {context}]
+
+:_mod-docs-content-type: ASSEMBLY
+
+ifndef::context[]
+[id="about-the-command-line-tool"]
+endif::[]
+ifdef::context[]
+[id="about-the-command-line-tool_{context}"]
+endif::[]
+= About the {ProductShortName} commands
+
+:context: about-the-command-line-tool
+
+[role="_abstract"]
+As a migrator, you can use a structured command model that consists of seven main commands to improve your experience and align with standard command-line interface (CLI) patterns.
+
+include::topics/mta-cli/con_cli-command-structure.adoc[leveloffset=+1]
+
+include::topics/mta-cli/ref_deprecated-commands-and-options.adoc[leveloffset=+1]
+
+include::topics/mta-cli/ref_backward-compatibility.adoc[leveloffset=+1]
+
+
+ifdef::parent-context-of-about-the-command-line-tool[:context: {parent-context-of-about-the-command-line-tool}]
+ifndef::parent-context-of-about-the-command-line-tool[:!context:]

--- a/assemblies/cli-guide/assembly_analyzing-nonjava-applications.adoc
+++ b/assemblies/cli-guide/assembly_analyzing-nonjava-applications.adoc
@@ -30,6 +30,8 @@ include::topics/mta-cli/proc_analyze-selected-provider.adoc[leveloffset=+1]
 
 include::topics/mta-cli/proc_analyze-unsupported-provider.adoc[leveloffset=+1]
 
+include::topics/mta-cli/ref_provider-and-rules-command-options.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 == Additional resources
 * xref:running-the-containerless-mta-cli_analyzing-applications-mta-cli[Analyzing an application in containerless mode]

--- a/assemblies/cli-guide/assembly_performing-transformation.adoc
+++ b/assemblies/cli-guide/assembly_performing-transformation.adoc
@@ -19,7 +19,7 @@ endif::[]
 [role="_abstract"]
 To accelerate your application modernization, use the {ProductFullName} command-line interface (CLI) to transform your source code. The transformation process applies predefined migration rules to your codebase, reducing the manual effort required to update Java libraries or frameworks.
 
-IMPORTANT: Performing transformation requires the container runtime to be configured. 
+NOTE: Performing transformation requires the container runtime to be configured. 
  
 
 include::topics/mta-cli/proc_transforming-application-source-code.adoc[leveloffset=+1]

--- a/docs/cli-guide/master.adoc
+++ b/docs/cli-guide/master.adoc
@@ -8,6 +8,8 @@ include::topics/templates/document-attributes.adoc[]
 
 include::topics/mta-cli/con_intro-to-the-cli.adoc[leveloffset=+1]
 
+include::assemblies/cli-guide/assembly_about-the-command-line-tool.adoc[leveloffset=+1]
+
 include::topics/mta-cli/ref_supported-migration-paths.adoc[leveloffset=+1]
 
 include::assemblies/cli-guide/assembly_analyzing-applications-mta-cli.adoc[leveloffset=+1]

--- a/docs/topics/mta-cli/con_cli-command-structure.adoc
+++ b/docs/topics/mta-cli/con_cli-command-structure.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * assemblies/cli-guide/assembly_about-the-command-line-tool.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cli-command-structure_{context}"]
+= CLI command structure
+
+[role="_abstract"]
+To help you understand the purpose of a command and to easily classify tasks, the {ProductFullName} command-line interface (CLI) organizes subcommands and options under main commands.
+
+You can use the following commands in the {ProductShortName} CLI:
+
+`mta-cli analyze`::
+Provides options to specify runtime settings for the analysis type or mode, single or one or more input applications, dependencies, rules, source or target technologies, proxy URL, a local or a containerized run, and the analysis output.
+
+`mta-cli rules`::
+Provides subcommands to list source and target technologies and to test rules that are available to analyze them. You can test default and custom rulesets.
+
+`mta-cli provider`::
+Provides subcommands to list the language-specific providers. Providers work with language server protocol (LSP) servers to parse the application source code and find specific problem patterns that you define in the rules.
+
+`mta-cli openrewrite`::
+Provides subcommands and options to use OpenRewrite recipes to transform your codebase by updating Java libraries and frameworks for a target technology.
+
+`mta-cli config`::
+Provides subcommands to log in to the {ProductShortName} Hub by using a secure or an insecure connection to sync, download, and manage a reusable analysis configuration file, called a profile, on your local system.
+
+`mta-cli discover`::
+Provides a subcommand and options to generate a local YAML manifest from application manifests in the Cloud Foundry (CF) source platform. You can filter CF applications by organization, space, and a specific application name. You can also redact sensitive information, such as usernames and secrets, in the discovery manifest.
+
+`mta-cli generate`::
+Provides a subcommand and options to generate Kubernetes and non-Kubernetes deployment manifests by using Helm templates and value overrides.
+
+[NOTE]
+====
+The options for `config`, `discover`, and `generate` commands are unchanged.
+====

--- a/docs/topics/mta-cli/proc_analyze-selected-provider.adoc
+++ b/docs/topics/mta-cli/proc_analyze-selected-provider.adoc
@@ -22,14 +22,14 @@ You can select a language provider to analyze from the list of supported provide
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --list-providers*
+$ mta-cli provider list
 ....
 
 . Run the application analysis for the selected language provider: 
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --input _<path_to_input>_ --output _<path_to_output>_ --provider _<language_provider>_ --rules _<path_to_custom_rules>_*
+$ mta-cli analyze --input _<path_to_input>_ --output _<path_to_output>_ --provider _<language_provider>_ --rules _<path_to_custom_rules>_
 ....
 +
 IMPORTANT: Note that if you do not set the `--provider` option, the analysis might fail because it detects unsupported providers. The analysis will complete without `--provider` only if all discovered providers are supported. 

--- a/docs/topics/mta-cli/proc_analyze-unsupported-provider.adoc
+++ b/docs/topics/mta-cli/proc_analyze-unsupported-provider.adoc
@@ -41,5 +41,5 @@ IMPORTANT: You must create a configuration file for your unsupported language pr
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --provider-override _<path_to_configuration_file>_ --output _<path_to_output>_ --rules _<path_to_custom_rules>_*
+$ mta-cli analyze --provider-override _<path_to_configuration_file>_ --output _<path_to_output>_ --rules _<path_to_custom_rules>_
 ....

--- a/docs/topics/mta-cli/proc_analyzing-app-with-profile.adoc
+++ b/docs/topics/mta-cli/proc_analyzing-app-with-profile.adoc
@@ -21,14 +21,14 @@ Migrators can use analysis profiles and custom rules downloaded from the {Produc
 +
 [subs="+quotes"]
 ----
-$ *mta-cli config login* 
+$ mta-cli config login 
 ----
 
 . Enter the `Host`, `Username`, and `Password` to connect to the Hub.
 +
 [subs="+quotes"]
 ----
-$ *mta-cli config login*
+$ mta-cli config login
 ----
 +
 [subs="+quotes"]
@@ -45,7 +45,7 @@ Password: _<my_password>_
 +
 [subs="+quotes, macros"]
 ....
-$ *mta-cli config sync --url \https://github.com/_<my_app_repository>_ --application-path _<path_to_my_app>_ --insecure*
+$ mta-cli config sync --url \https://github.com/_<my_app_repository>_ --application-path _<path_to_my_app>_ --insecure
 ....
 +
 [NOTE]
@@ -57,14 +57,14 @@ $ *mta-cli config sync --url \https://github.com/_<my_app_repository>_ --applica
 +
 [subs="+quotes"]
 ----
-$ *mta-cli config list --profile-dir _<path_to_my_app>_*
+$ mta-cli config list --profile-dir _<path_to_my_app>_
 ----
 
 . Run an analysis by using the downloaded profile configuration.
 +
 [subs="+quotes"]
 ----
-$ *mta-cli analyze -i _<path_to_my_app>_ -o _<path_to_my_app_report>_ --overwrite --mode source-only*
+$ mta-cli analyze -i _<path_to_my_app>_ -o _<path_to_my_app_report>_ --overwrite --mode source-only
 ----
 +
 [TIP]
@@ -78,7 +78,7 @@ The following command overrides the values of `target` in the analysis profile w
 
 [subs="+quotes"]
 ----
-$ *mta-cli analyze -i _<path_to_my_app>_ -o _<path_to_my_app_report>_ --overwrite --target quarkus --mode source-only*
+$ mta-cli analyze -i _<path_to_my_app>_ -o _<path_to_my_app_report>_ --overwrite --target quarkus --mode source-only
 ----
 ====
 

--- a/docs/topics/mta-cli/proc_analyzing-multiple-apps-with-mta-cli.adoc
+++ b/docs/topics/mta-cli/proc_analyzing-multiple-apps-with-mta-cli.adoc
@@ -31,21 +31,21 @@ For example, to analyze example applications `A`, `B`, and `C`, enter the follow
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --bulk --input _<path_to_input_A>_ --output _<path_to_output_ABC>_ --source _<source_A>_ --target _<target_A>_*
+$ mta-cli analyze --bulk --input _<path_to_input_A>_ --output _<path_to_output_ABC>_ --source _<source_A>_ --target _<target_A>_
 ....
 
 .. For input `B`, enter:
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --bulk --input _<path_to_input_B>_ --output _<path_to_output_ABC>_  --source _<source_B>_ --target _<target_B>_*
+$ mta-cli analyze --bulk --input _<path_to_input_B>_ --output _<path_to_output_ABC>_  --source _<source_B>_ --target _<target_B>_
 ....
 
 .. For input `C`, enter:
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --bulk --input _<path_to_input_C>_ --output _<path_to_output_ABC>_  --source _<source_C>_ --target _<target_C>_*
+$ mta-cli analyze --bulk --input _<path_to_input_C>_ --output _<path_to_output_ABC>_  --source _<source_C>_ --target _<target_C>_
 ....
 
 . Access the analysis report. {ProductShortName} generates a single report, listing all issues that must be resolved before the applications can be migrated.

--- a/docs/topics/mta-cli/proc_analyzing-single-app-with-mta-cli.adoc
+++ b/docs/topics/mta-cli/proc_analyzing-single-app-with-mta-cli.adoc
@@ -8,7 +8,7 @@
 [role="_abstract"]
 To assess the effort required to migrate a specific application, you can analyze this application individually by using the {ProductFullName} command-line interface (CLI). 
 
-The analysis generates a report containing the details of the application migration effort, including potential migration issues. You can use the report to prioritize tasks and estimate the resources needed for the migration.
+You can run an analysis to generate a report that contains migration effort, including potential issues. You can use the report to prioritize tasks and estimate the resources that you need for the migration.
 
 NOTE: Extracting the list of dependencies from compiled Java binaries is not always possible during the analysis, especially if the dependencies are not embedded within the binary.
 
@@ -18,14 +18,14 @@ NOTE: Extracting the list of dependencies from compiled Java binaries is not alw
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --list-targets*
+$ mta-cli rules list-targets
 ....
 
 . Run the analysis:
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --input _<path_to_input>_ --output _<path_to_output>_ --source _<source_name>_ --target _<target_name_>*
+$ mta-cli analyze --input _<path_to_input>_ --output _<path_to_output>_ --source _<source_name>_ --target _<target_name_>
 ....
 +
 Specify the following arguments:

--- a/docs/topics/mta-cli/proc_assets-generation-example.adoc
+++ b/docs/topics/mta-cli/proc_assets-generation-example.adoc
@@ -33,7 +33,7 @@ Assume that the `cf-nodejs-app.yaml` is located in the same directory as the {Pr
 +
 [subs="+quotes"]
 ----
-$ *cat cf-nodejs-app.yaml*
+$ cat cf-nodejs-app.yaml
 ----
 +
 [subs="+quotes"]
@@ -52,16 +52,16 @@ random-route: true
 +
 [subs="+quotes"]
 ----
-$ *mta-cli discover cloud-foundry \
+$ mta-cli discover cloud-foundry \
 --input cf-nodejs-app.yaml \
---output discover.yaml \*
+--output discover.yaml \
 ----
 
 . Verify the content of the discover manifest:
 +
 [subs="+quotes"]
 ----
-$ *cat discover.yaml*
+$ cat discover.yaml
 ----
 +
 [subs="+quotes"]
@@ -79,16 +79,16 @@ instances: 1
 +
 [subs="+quotes"]
 ----
-$ *mta-cli generate helm \
+$ mta-cli generate helm \
 --chart-dir helm_sample \
---input discover.yaml --output-dir newDir*
+--input discover.yaml --output-dir newDir
 ----
 
 . Check the contents of the Dockerfile in the `newDir` directory:
 +
 [subs="+quotes"]
 ----
-$ *cat ./newDir/Dockerfile*
+$ cat ./newDir/Dockerfile
 ----
 +
 [subs="+quotes"]
@@ -102,7 +102,7 @@ RUN echo "Hello cf-nodejs!"
 +
 [subs="+quotes"]
 ----
-$ *cat ./newDir/configmap.yaml*
+$ cat ./newDir/configmap.yaml
 ----
 +
 [subs="+quotes"]
@@ -124,11 +124,11 @@ data:
 +
 [subs="+quotes"]
 ----
-$ *mta-cli generate helm \
+$ mta-cli generate helm \
 --chart-dir helm_sample \
 --input discover.yaml --set name="nodejs-app" \
 --set instances=2 \
---output-dir newDir \*
+--output-dir newDir \
 ----
 
 . Check the contents of the ConfigMap again:

--- a/docs/topics/mta-cli/proc_generate_deployment_assets_values_file.adoc
+++ b/docs/topics/mta-cli/proc_generate_deployment_assets_values_file.adoc
@@ -56,10 +56,10 @@ ENV REDIS_URL={{ .Values.manifest.redis.url }}
 +
 [subs="+quotes"]
 ----
-$ *mta-cli generate helm --chart-dir _<path_to_helm_chart>_* \
-  *--input _<path_to_discovery_manifest>_* \
-  *--set manifest.name=my-new-app* \
-  *--output-dir _<location_of_deployment_manifests>_*
+$ mta-cli generate helm --chart-dir _<path_to_helm_chart>_ \
+  --input _<path_to_discovery_manifest>_ \
+  --set manifest.name=my-new-app \
+  --output-dir _<location_of_deployment_manifests>_
 ----
 +
 where:
@@ -79,7 +79,7 @@ The variable priority for generating deployment manifests is as follows:
 +
 [subs="+quotes"]
 ----
-$ *cat _<path_to_dockerfile>_*
+$ cat _<path_to_dockerfile>_
 ----
 +
 [source, yaml]

--- a/docs/topics/mta-cli/proc_generating-discovery-manifest.adoc
+++ b/docs/topics/mta-cli/proc_generating-discovery-manifest.adoc
@@ -24,14 +24,14 @@ You can generate the discovery manifest for the Cloud Foundry (CF) application b
 +
 [subs="+quotes"]
 ----
-$ *mta-cli discover --list-platforms*
+$ mta-cli discover --list-platforms
 ----
 
 . Generate the discovery manifest:
 +
 [subs="+quotes"]
 ----
-$ *mta-cli discover cloud-foundry --input _<path_to_input>_ --output-dir _<path_to_output-directory>_*
+$ mta-cli discover cloud-foundry --input _<path_to_input>_ --output-dir _<path_to_output-directory>_
 ----
 
 [role="_additional-resources"]

--- a/docs/topics/mta-cli/proc_performing-a-live-discovery.adoc
+++ b/docs/topics/mta-cli/proc_performing-a-live-discovery.adoc
@@ -34,26 +34,26 @@ IMPORTANT: You must enter at least one Cloud Foundry organization by using the `
 +
 [subs="+quotes"]
 ....
-$ *cf spaces*
+$ cf spaces
 ....
 +
 [subs="+quotes"]
 ....
-$ *cf apps*
+$ cf apps
 ....
 
 . Copy the CF configuration file to the directory of your choice:
 +
 [subs="+quotes"]
 ....
-$ *mkdir _<path_to_the_directory>_/.cf*
+$ mkdir _<path_to_the_directory>_/.cf
 ....
 
 . Run the live discovery in a remote CF instance:
 +
 [subs="+quotes"]
 ....
-$ *mta-cli discover cloud-foundry --use-live-connection --orgs=_<org_name>_ --spaces=_<space_name>_  --output-dir _<path_to_output_directory>_ --cf-config=_<path_to_CF_config_file>_*
+$ mta-cli discover cloud-foundry --use-live-connection --orgs=_<org_name>_ --spaces=_<space_name>_  --output-dir _<path_to_output_directory>_ --cf-config=_<path_to_CF_config_file>_
 ....
 +
 The command runs the discovery for all applications from each space in the specified organization.
@@ -62,5 +62,5 @@ If you want to run the discovery for a specific application, enter, for example:
 +
 [subs="+quotes"]
 ....
-$ *mta-cli discover cloud-foundry --use-live-connection --orgs=_<org_name>_  --spaces=_<space_name>_ --app-name=_<application_name>_ --output-dir _<path_to_output_directory>_ --cf-config=_<path_to_CF_config_file>_* 
+$ mta-cli discover cloud-foundry --use-live-connection --orgs=_<org_name>_  --spaces=_<space_name>_ --app-name=_<application_name>_ --output-dir _<path_to_output_directory>_ --cf-config=_<path_to_CF_config_file>_
 ....

--- a/docs/topics/mta-cli/proc_running-the-containerless-mta-cli.adoc
+++ b/docs/topics/mta-cli/proc_running-the-containerless-mta-cli.adoc
@@ -43,14 +43,14 @@ NOTE: If you do not set `JVM_MAX_MEM`, the analysis might hang because Java migh
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --help*
+$ mta-cli analyze --help
 ....
 
 . Run the application analysis:
 +
 [subs="+quotes"]
 ....
-$ *mta-cli analyze --overwrite --input _<path_to_input>_  --output _<path_to_output>_ --target _<target_source>_*
+$ mta-cli analyze --overwrite --input _<path_to_input>_  --output _<path_to_output>_ --target _<target_source>_
 ....
 +
 NOTE: The `--overwrite` option overwrites the output folder if it exists.

--- a/docs/topics/mta-cli/proc_transforming-application-source-code.adoc
+++ b/docs/topics/mta-cli/proc_transforming-application-source-code.adoc
@@ -6,7 +6,7 @@
 = Transforming applications source code
 
 [role="_abstract"]
-To update Java libraries or frameworks, for example, `javax` or Spring Boot, you can transform Java application source code by using the `transform openrewrite` command. The `openrewrite` subcommand allows running `OpenRewrite` recipes on source code. Transformation applies predefined migration rules to your codebase, reducing the manual effort required to update Java libraries or frameworks.	
+To update Java libraries or frameworks, for example, `javax` or Spring Boot, you can transform Java application source code by using the `mta-cli openrewrite` command. The `openrewrite` subcommand allows running `OpenRewrite` recipes on source code. Transformation applies predefined migration rules to your codebase, reducing the manual effort required to update Java libraries or frameworks.	
 
 NOTE: You can only use a single target to run the `transform overwrite` command. 		
 
@@ -21,15 +21,19 @@ NOTE: You can only use a single target to run the `transform overwrite` command.
 +
 [literal,subs="+quotes,verbatim,normal,normal"]
 ....
-$ *mta-cli transform openrewrite --list-targets*
+$ mta-cli openrewrite --list-targets
 ....
 
 . Transform the application source code:
 +
 [literal,subs="+quotes,verbatim,normal,normal"]
 ....
-$ *mta-cli transform openrewrite --input=_<path_to_source_code>_ --target=_<target_from_the_list>_*
+$ mta-cli openrewrite --input=_<path_to_source_code>_  \
+--target=_<target_from_the_list>_
 ....
+where:
+ * _<path_to_source_code>_: Specifies the system path to the source code
+ * _<target_from_the_list>_: Specifies the OpenRewrite recipe for the target 
 
 
 .Verification

--- a/docs/topics/mta-cli/ref_backward-compatibility.adoc
+++ b/docs/topics/mta-cli/ref_backward-compatibility.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * assemblies/cli-guide/assembly_about-the-command-line-tool.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="backward-compatibility_{context}"]
+= Compatibility with deprecated commands
+
+[role="_abstract"]
+To ensure compatibility with the earlier versions, the {ProductFullName} CLI converts an unsupported commands and options to the equivalent supported commands.
+
+For example, if you enter:
+
+[subs="+quotes"]
+----
+$ mta-cli analyze --list-targets
+----
+
+The {ProductShortName} CLI processes the command as:
+
+[subs="+quotes"]
+----
+$ mta-cli rules list-targets
+----

--- a/docs/topics/mta-cli/ref_deprecated-commands-and-options.adoc
+++ b/docs/topics/mta-cli/ref_deprecated-commands-and-options.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * assemblies/cli-guide/assembly_about-the-command-line-tool.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="deprecated-commands-and-options_{context}"]
+= Deprecated commands and options
+
+[role="_abstract"]
+You can use the `mta-cli provider` and `mta-cli rules` commands that have a set of subcommands that you previously used with the `analyze` commands. The `mta-cli test` and `mta-cli transform` commands are deprecated.
+
+To view the options and flags for any {ProductShortName} command, use the `--help` or the `-h` option.
+
+.Deprecated commands and their replacements
+[cols="1,1",options="header"]
+|===
+|Deprecated command
+|New command
+
+|$ mta-cli analyze --list-targets
+|$ mta-cli rules list-targets
+
+|$ mta-cli analyze --list-sources
+|$ mta-cli rules list-sources
+
+|$ mta-cli analyze --list-providers
+|$ mta-cli provider list
+
+a|$ mta-cli test <path_to_test_ruleset>
+
+where:
+
+`<path_to_test_ruleset>`:: Specifies the system path to the test ruleset.
+
+a|$ mta-cli rules test <path_to_test_ruleset>
+
+where:
+
+`<path_to_test_ruleset>`:: Specifies the system path to the test ruleset.
+
+|$ mta-cli transform
+|$ mta-cli openrewrite
+
+|===

--- a/docs/topics/mta-cli/ref_mta-cli-analyze-flags.adoc
+++ b/docs/topics/mta-cli/ref_mta-cli-analyze-flags.adoc
@@ -35,9 +35,6 @@ By default, `--disable-maven-search=false`. Therefore, {ProductShortName} uses t
 |`--json-output` (string)|Create analysis and dependence output as a JSON file.
 |`--label-selector` (string)|Run rules based on specified label selector expression.
 | `--list-languages` |List all languages in the source application. This flag is not supported for binary applications.
-| `--list-providers` |List available supported providers.
-|`--list-sources`|List rules for available migration sources.
-|`--list-targets`|List rules for available migration targets.
 |`--maven-settings` (string)|A path to the custom Maven settings file to use.
 |`--mode` (string) a|An analysis mode. Must be set to either of the following values:
 

--- a/docs/topics/mta-cli/ref_openrewrite-command-options.adoc
+++ b/docs/topics/mta-cli/ref_openrewrite-command-options.adoc
@@ -6,7 +6,7 @@
 = The openrewrite command options
 
 [role="_abstract"]
-The {ProductFullName} command-line interface (CLI) provides the `mta-cli transform openrewrite` command options to customize the transformation of your application source code. Check the following table to identify the available arguments for applying specific migration recipes and controlling the output of the transformation process.
+The {ProductFullName} command-line interface (CLI) provides the `mta-cli  openrewrite` command options to customize the transformation of your application source code. Check the following table to identify the available arguments for applying specific migration recipes and controlling the output of the transformation process.
 
 .The `mta-cli transform openrewrite` command options
 [options="header"]

--- a/docs/topics/mta-cli/ref_provider-and-rules-command-options.adoc
+++ b/docs/topics/mta-cli/ref_provider-and-rules-command-options.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * assemblies/cli-guide/assembly_about-the-command-line-tool.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="provider-and-rules-command-options_{context}"]
+= The provider and rules command options
+
+[role="_abstract"]
+You can list providers by using the `mta-cli provider` command and specify a provider during runtime when you analyze a non-Java application. Run the `mta-cli rules` command to list the available source and target technologies for migration and to test rules.
+
+.The provider and rules commands and options
+[cols="1,1,2,2",options="header"]
+|===
+|Command
+|Subcommands and options
+|Description
+|Command syntax 
+
+|`mta-cli provider`
+|`list`
+|List available and supported providers
+|*mta-cli provider list*
+
+.3+|`mta-cli rules`
+|`list-sources`
+|List rules for available migration sources
+|*mta-cli rules list-sources*
+
+|`list-targets`
+|List rules for available migration targets
+|*mta-cli rules list-targets*
+
+|`test`
+|Validate a default or a custom rule or a ruleset against a sample application code. The CLI shows test result status, pass or fail, for all rules in a ruleset.
+a|*mta-cli rules test _<path_to_test_rules>_*
+
+where:
+
+* _<path_to_test_rules>_:: Specifies the system path to the rules you want to test.
+
+|===


### PR DESCRIPTION
### JIRA

* [MTA-6889](https://redhat.atlassian.net/browse/MTA-6889)

### Version 

* 8.2.0

### Previews
* [2. About the MTA commands](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#about-the-command-line-tool_cli-guide) 
* [2.1. CLI command structure](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#cli-command-structure_about-the-command-line-tool)
* [2.2. Deprecated commands and options](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#deprecated-commands-and-options_about-the-command-line-tool)
* [2.3. Compatibility with deprecated commands](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#backward-compatibility_about-the-command-line-tool)
* [5.3. The provider and rules command options](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#provider-and-rules-command-options_analyzing-nonjava-applications)
* [4.1. Analyzing a single application - minor correction in the first step](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#analyzing-single-app-wth-mta-cli_analyzing-applications-mta-cli)
* [4.4. The analyze command options - removed provider, source, and target flags](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#mta-cli-analyze-flags_analyzing-applications-mta-cli)
* [8.1. Transforming applications source code - minor command correction](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#transforming-application-source-code_performing-transformation)
* [8.3. The openrewrite command options - minor command correction](https://pkylas007.github.io/Preview/MTA/mta-6889/index.html#openrewrite-command-options_performing-transformation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added a new CLI guide section (“About the {ProductShortName} commands”) and included it in the main guide.
  * Added new topics for CLI command structure, backward compatibility, deprecated commands/options, and provider/rules options (including `openrewrite`).
  * Updated procedures and reference pages to match the restructured CLI syntax (for example, using `mta-cli provider list`, `mta-cli rules list-targets`, and `mta-cli openrewrite ...`), and removed outdated `transform openrewrite` references.
  * Refreshed many command examples’ presentation and adjusted a transformation callout label (IMPORTANT → NOTE).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->