### PR TITLE
Add profile sync prerequisites in the Visual Studio Code guide

### DIFF
--- a/docs/topics/mta-cli/proc_analyzing-app-with-profile.adoc
+++ b/docs/topics/mta-cli/proc_analyzing-app-with-profile.adoc
@@ -13,6 +13,7 @@ Migrators can use analysis profiles and custom rules downloaded from the {Produc
 * Your Administrator installed {ProductShortName} and the `tackle` operator in your cluster.
 * The Architect configured an analysis profile with required custom rules in the {ProductShortName} {WebName}. 
 * The Architect added the analysis profile in the application's target profile in the {ProductShortName} {WebName}. 
+* In the {ProductShortName} {WebName}, the application has a tag that matches an archetype tag.
 * The application you want to sync is available in your local system.
 
 .Procedure

--- a/docs/topics/mta-ui/proc_configuring-target-profiles.adoc
+++ b/docs/topics/mta-ui/proc_configuring-target-profiles.adoc
@@ -24,6 +24,6 @@ The *Target profiles for _<archetype_name>_* is displayed.
 . In the *Name* field in the opened dialogue, enter a unique name for the target profile.
 . Click the *Tag category* field and select the category tag to associate with the tag.
 . Select specific generators and click the right arrow to move the generator from the *Available generators* list to the *Chosen generators* list.
-. (Optional) Select an analysis profile for the application from the list. You can download this profile configuration from the {ProductShortName} {CLIName} only if you select the profile from this list.
+. Optional: Select an analysis profile for the application from the list. You can download the profile configuration from the {ProductShortName} {CLIName} and the Visual Studio Code extension only if you select the profile from this list.
 . Click *Create*.
 . You can click the archetype row to open the archetype detail view where the target profiles for the archetype are listed.

--- a/docs/topics/vscode/proc_vscode-analyzing-application-using-profiles.adoc
+++ b/docs/topics/vscode/proc_vscode-analyzing-application-using-profiles.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="analyzing-application-profiles_{context}"]
-= Running an application analysis by using a profile
+= Running an application analysis by using a Hub profile
 
 [role="_abstract"]
 To run a static code analysis of an application, you can use a profile that is created and managed by your architect in the {ProductFullName} Hub. 
@@ -23,7 +23,11 @@ For more information about the support scope of Red Hat Technology Preview featu
 .Prerequisites
 
 * You opened a project written in one of the supported languages in your Visual Studio Code workspace. {ProductShortName} can analyze source code written in `Java`, `C#`, `.NET`, `Go`, and `JavaScript`.
-* An architect has configured an analysis profile in the Hub.
+* An architect has configured an analysis profile in the {ProductShortName} web console.
+* The repository URL of the local application matches an existing application in the {ProductShortName} web console.
+* The application has a tag that matches the criteria tag in an archetype.
+* The archetype has at least one target profile.
+* The architect selected the analysis profile in the target profile. 
 
 .Procedure
 
@@ -37,10 +41,12 @@ For more information about the support scope of Red Hat Technology Preview featu
 .. If you want to connect to your Hub without verifying the local SSL certificate in the host, enable *Skip SSL certificate verification*. 
 .. Log in to the Hub by enabling the *Enable authentication* switch.
 .. Enter the username and password credentials of the {ProductShortName} user interface.
-.. To use the Solution Server to suggest resolutions for the issues in the source code, enable *Solution Server* .
-.. To sync the profiles with the Hub, enable *Profile Sync*. {ProductShortName} periodically downloads the latest version of the profiles from the Hub. 
+.. To generate code resolutions for the issues in your source code by using the Solution Server, enable *Solution Server*.
 +
-{ProductShortName} does not update the profiles and rules if you do not sync the profiles with the Hub. When you enable the profile sync and the administrator has deployed LLM proxy in the cluster, {ProductShortName} uses the proxy service to connect to the LLM.
+When you enable the Solution Server and the administrator has deployed LLM proxy in the cluster, {ProductShortName} uses the proxy service to connect to the LLM.
+.. To synchronize the profiles with the Hub, enable *Profile Sync*. {ProductShortName} periodically downloads the latest version of the profiles from the Hub. 
++
+To update the profiles and rules, you must synchronize them profiles with the Hub. 
 
 . Select a profile from the list on the *{ProductShortName} Analysis View* page.
 . Click *Run Analysis*.


### PR DESCRIPTION
### JIRA

* [MTA-7145](https://redhat.atlassian.net/browse/MTA-7145)

### Version 

* 8.1.0

### Previews

* [7. Running an application analysis by using a Hub profile - Added web console prerequisites for profile sync in VS Code IDE](https://pkylas007.github.io/Preview/MTA/profile-sync-prereq/index.html#analyzing-application-profiles_vsc-extension-guide)
* [13.2. Configuring a target profile - added Visual Studio Code in step 7](https://pkylas007.github.io/Preview/MTA/profile-sync-web-ui/index.html#configuring-target-profiles_asset-generation-ui)
* [5.1. Analyzing an application by using a profile - Added the archetype tag match detail in the prerequisites](https://pkylas007.github.io/Preview/MTA/profile-sync-cli-prereq/index.html#analyzing-app-with-profile_analyzing-apps-profiles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified target profile configuration flow, including when profile settings can be downloaded via the CLI and Visual Studio Code.
  * Updated “analyzing application using profiles” guidance to use a Hub profile, with more explicit prerequisites (repository match, tag/archetype matching, and target profile presence/selection).
  * Refined Hub configuration instructions, including Solution Server (when applicable) and clearer wording on how profile/rule updates behave with profile synchronization.
  * Added a missing tag-matching prerequisite for CLI-based analysis with an uploaded profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->