### PR TITLE
MTA-7036: adding requirements for ISO-42001

### DIFF
--- a/docs/topics/developer-lightspeed/assembly_configuring_llm.adoc
+++ b/docs/topics/developer-lightspeed/assembly_configuring_llm.adoc
@@ -34,6 +34,8 @@ You can also run OpenAI API-compatible LLMs deployed as:
 * A service in your {ocp-name} AI cluster
 * Locally in the Podman AI Lab in your system.
 
+include::con_ip-protection-model-hosting.adoc[leveloffset=+1]
+
 include::con_llm-service-openshift-ai.adoc[leveloffset=+1]
 
 include::ref_llm-provider-configurations.adoc[leveloffset=+1]

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -23,7 +23,7 @@ When you configure {mta-dl-plugin} to use a public, SaaS-based LLM endpoint (suc
 ====
 
 [id="ip-protection-mitigation_{context}"]
-== Recommended mitigation: Self-managed model hosting
+== Self-managed model hosting as a mitigation strategy
 
 Organizations with strict intellectual property (IP) protection requirements, regulatory constraints, or air-gapped network environments should deploy a self-managed LLM instance and configure {mta-dl-plugin} to route all queries to that private endpoint. This approach ensures that source code snippets never leave your controlled infrastructure.
 

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -42,6 +42,6 @@ A self-managed model requires the {mta-dl-plugin} default large language model (
 
 * *Standalone mode*: The custom endpoint URL is configured in the VS Code extension settings for {mta-dl-plugin}.
 
-* *Centralized configuration management mode*: Set the provider endpoint URL in the central configuration administered through the {ProductShortName} hub.
+* *Centralized configuration management mode*: The provider endpoint URL is set in the central configuration administered through the {ProductShortName} hub.
 
 Self-managed endpoints require authentication credentials, such as API keys or bearer tokens. These credentials require secure storage and must not be committed to source control.

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -15,7 +15,9 @@ Configuring a large language model (LLM) provider for {mta-dl-full} requires an 
 [id="ip-protection-risk-disclosure_{context}"]
 == {mta-dl-plugin} code transmission to the LLM
 
-To generate accurate migration suggestions, {mta-dl-plugin} constructs a contextual prompt that includes relevant code snippets from the application that you are analyzing. These snippets are transmitted intact to the configured LLM provider. {mta-dl-plugin} does not perform automatic sanitization or redaction of source code before the code is included in a prompt, because altering the code syntax reduces the accuracy of the migration recommendations.
+To generate accurate migration suggestions, {mta-dl-plugin} constructs a contextual prompt. This prompt includes relevant code snippets from the application that you are analyzing. Code snippets are transmitted intact to the configured LLM provider. 
+
+{mta-dl-plugin} does not perform automatic sanitization or redaction of source code before inclusion in a prompt. Altering the code syntax reduces the accuracy of the migration recommendations.
 
 [WARNING]
 ====

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -19,7 +19,9 @@ To generate accurate migration suggestions, {mta-dl-plugin} constructs a context
 
 [WARNING]
 ====
-When you configure {mta-dl-plugin} to use a public, SaaS-based LLM endpoint (such as a public OpenAI service or a shared Azure OpenAI deployment), {mta-dl-plugin} transmits your source code snippets to that third-party provider for processing. If your codebase contains proprietary algorithms, trade secrets, regulated data, or other sensitive intellectual property, this transmission might expose that information outside your organization's security boundary. This exposure might conflict with your intellectual property protection policies, contractual obligations, or regulatory requirements.
+You can configure {mta-dl-plugin} to use a public, SaaS-based LLM endpoint, such as a public OpenAI service or a shared Azure OpenAI deployment. If you do this, {mta-dl-plugin} transmits your source code snippets to that third-party provider for processing.
+
+Your codebase might contain proprietary algorithms, trade secrets, regulated data, or other sensitive intellectual property. This transmission might expose that information outside your organization's security boundary. This exposure might conflict with your intellectual property protection policies, contractual obligations, or regulatory requirements.
 ====
 
 [id="ip-protection-mitigation_{context}"]

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -36,7 +36,7 @@ Red{nbsp}Hat supports the following on-site and self-managed AI platforms for th
 You can configure {mta-dl-plugin} to use the OpenAI-compatible API endpoint that both platforms expose without any additional plugin changes.
 
 [id="ip-protection-config-pointers_{context}"]
-== Configuring {mta-dl-plugin} to use a private endpoint
+== Private endpoint configuration
 
 After you deploy a self-managed model, override the default LLM provider URL in {mta-dl-plugin} to point to your private inference endpoint:
 

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -44,4 +44,4 @@ After you deploy a self-managed model, override the default LLM provider URL in 
 
 * *Centralized configuration management mode*: Set the provider endpoint URL in the central configuration administered through the {ProductShortName} hub.
 
-Ensure that you securely store any authentication credentials that your self-managed endpoint requires (such as API keys or bearer tokens) and do not commit them to source control.
+Self-managed endpoints require authentication credentials, such as API keys or bearer tokens. These credentials require secure storage and must not be committed to source control.

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -38,7 +38,7 @@ You can configure {mta-dl-plugin} to use the OpenAI-compatible API endpoint that
 [id="ip-protection-config-pointers_{context}"]
 == Private endpoint configuration
 
-After you deploy a self-managed model, override the default LLM provider URL in {mta-dl-plugin} to point to your private inference endpoint:
+A self-managed model requires the {mta-dl-plugin} default large language model (LLM) provider URL to point to a private inference endpoint. The URL location depends on your deployment:
 
 * *Standalone mode*: Configure the custom endpoint URL in the VS Code extension settings for {mta-dl-plugin}.
 

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -40,7 +40,7 @@ You can configure {mta-dl-plugin} to use the OpenAI-compatible API endpoint that
 
 A self-managed model requires the {mta-dl-plugin} default large language model (LLM) provider URL to point to a private inference endpoint. The URL location depends on your deployment:
 
-* *Standalone mode*: Configure the custom endpoint URL in the VS Code extension settings for {mta-dl-plugin}.
+* *Standalone mode*: The custom endpoint URL is configured in the VS Code extension settings for {mta-dl-plugin}.
 
 * *Centralized configuration management mode*: Set the provider endpoint URL in the central configuration administered through the {ProductShortName} hub.
 

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -10,7 +10,7 @@
 = Data privacy, intellectual property protection, and model hosting considerations
 
 [role="_abstract"]
-Configuring a large language model (LLM) provider for {mta-dl-full} requires an understanding of code transmission to the model and the implications for your organization's intellectual property (IP) and data privacy policies.
+When you configure a large language model (LLM) provider for {mta-dl-full}, understanding code transmission helps you to comply with your organization's intellectual property (IP) and data privacy policies.
 
 [id="ip-protection-risk-disclosure_{context}"]
 == {mta-dl-plugin} code transmission to the LLM

--- a/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
+++ b/docs/topics/developer-lightspeed/con_ip-protection-model-hosting.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * docs/developer-lightspeed-guide/master.adoc
+
+:_template-generated: 2026-06-29
+
+:_mod-docs-content-type: CONCEPT
+
+[id="ip-protection-model-hosting_{context}"]
+= Data privacy, intellectual property protection, and model hosting considerations
+
+[role="_abstract"]
+Configuring a large language model (LLM) provider for {mta-dl-full} requires an understanding of code transmission to the model and the implications for your organization's intellectual property (IP) and data privacy policies.
+
+[id="ip-protection-risk-disclosure_{context}"]
+== {mta-dl-plugin} code transmission to the LLM
+
+To generate accurate migration suggestions, {mta-dl-plugin} constructs a contextual prompt that includes relevant code snippets from the application that you are analyzing. These snippets are transmitted intact to the configured LLM provider. {mta-dl-plugin} does not perform automatic sanitization or redaction of source code before the code is included in a prompt, because altering the code syntax reduces the accuracy of the migration recommendations.
+
+[WARNING]
+====
+When you configure {mta-dl-plugin} to use a public, SaaS-based LLM endpoint (such as a public OpenAI service or a shared Azure OpenAI deployment), {mta-dl-plugin} transmits your source code snippets to that third-party provider for processing. If your codebase contains proprietary algorithms, trade secrets, regulated data, or other sensitive intellectual property, this transmission might expose that information outside your organization's security boundary. This exposure might conflict with your intellectual property protection policies, contractual obligations, or regulatory requirements.
+====
+
+[id="ip-protection-mitigation_{context}"]
+== Recommended mitigation: Self-managed model hosting
+
+Organizations with strict intellectual property (IP) protection requirements, regulatory constraints, or air-gapped network environments should deploy a self-managed LLM instance and configure {mta-dl-plugin} to route all queries to that private endpoint. This approach ensures that source code snippets never leave your controlled infrastructure.
+
+Red{nbsp}Hat supports the following on-site and self-managed AI platforms for this purpose:
+
+* *{ocp-name} AI*: Deploy and serve LLMs as an inference service within your {ocp-name} cluster. This keeps all model traffic on your internal network. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed[Red{nbsp}Hat OpenShift AI documentation].
+
+* *Red{nbsp}Hat Enterprise Linux AI (RHEL AI)*: Run a self-contained, production-ready AI infrastructure on RHEL to serve models locally or within your private data center. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_ai[Red{nbsp}Hat Enterprise Linux AI documentation].
+
+You can configure {mta-dl-plugin} to use the OpenAI-compatible API endpoint that both platforms expose without any additional plugin changes.
+
+[id="ip-protection-config-pointers_{context}"]
+== Configuring {mta-dl-plugin} to use a private endpoint
+
+After you deploy a self-managed model, override the default LLM provider URL in {mta-dl-plugin} to point to your private inference endpoint:
+
+* *Standalone mode*: Configure the custom endpoint URL in the VS Code extension settings for {mta-dl-plugin}.
+
+* *Centralized configuration management mode*: Set the provider endpoint URL in the central configuration administered through the {ProductShortName} hub.
+
+Ensure that you securely store any authentication credentials that your self-managed endpoint requires (such as API keys or bearer tokens) and do not commit them to source control.


### PR DESCRIPTION
---

### JIRA

* [MTA-7036](https://redhat.atlassian.net/browse/MTA-7036)

---

## DESCRIPTION

* Adds a new concept module, con_ip-protection-model-hosting.adoc, to the Developer Lightspeed LLM configuration chapter to address the ISO/IEC 42001 (Controls A.5.1 and A.10.4) compliance gap identified in MTA-7036.

The module covers:

* A disclosure that Developer Lightspeed transmits source code snippets intact to the configured LLM provider, with no automatic sanitization

* An [IMPORTANT] advisory on the IP and data privacy risks of using public SaaS-based LLM endpoints (such as public OpenAI or Azure OpenAI) with proprietary codebases

* Recommendations to use Red Hat OpenShift AI or Red Hat Enterprise Linux AI (RHEL AI) as self-managed, on-premise alternatives for organizations with strict IP policies, regulatory constraints, or air-gapped environments
Guidance on configuring a private endpoint in both standalone and centralized configuration management modes

* The module is included in assembly_configuring_llm.adoc ahead of the provider configuration reference so users see the advisory before selecting an endpoint.

---

## PREVIEW

* [3.1. Data privacy, intellectual property protection, and model hosting considerations](https://anarnold97.github.io/PREVIEW/MTA-7036.html#ip-protection-model-hosting_configuring-llm)
    * [3.1.1. Red Hat Developer Lightspeed for MTA code transmission to the LLM](https://anarnold97.github.io/PREVIEW/MTA-7036.html#ip-protection-risk-disclosure_configuring-llm)
    * [3.1.2. Recommended mitigation: Self-managed model hosting](https://anarnold97.github.io/PREVIEW/MTA-7036.html#ip-protection-mitigation_configuring-llm)
    * [3.1.3. Configuring Red Hat Developer Lightspeed for MTA to use a private endpoint](https://anarnold97.github.io/PREVIEW/MTA-7036.html#ip-protection-config-pointers_configuring-llm)
    
    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring LLM analysis with IP protection and model hosting options.
  * Documented privacy considerations when sending code snippets to external AI providers, including the fact that snippets are not automatically redacted.
  * Added recommendations for using self-managed AI platforms and private OpenAI-compatible endpoints, along with configuration guidance and credential-handling reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->