### PR TITLE
MTA-7174 Update required OpenShift versions in MTA Operator installation guide

### DIFF
--- a/docs/topics/mta-install/proc_installing-mta-operator.adoc
+++ b/docs/topics/mta-install/proc_installing-mta-operator.adoc
@@ -13,7 +13,7 @@ The {ProductShortName} Operator is a structural layer that manages resources dep
 .Prerequisites
 
 * Your environment has 4 vCPUs, 8 GB RAM, and 40 GB persistent storage.
-* Your environment uses Red Hat OpenShift (cloud service or self-hosted), version 4.13–4.15.
+* Your environment uses Red Hat OpenShift (cloud service or self-hosted), version 4.21–4.22.
 pass:[<!-- vale RedHat.Spelling = NO -->]
 * You created two RWO persistent volumes (PVs) used by different components.
 pass:[<!-- vale RedHat.Spelling = YES -->]


### PR DESCRIPTION
### JIRA

* [MTA-7174 Update required OpenShift versions in MTA Operator installation guide](https://redhat.atlassian.net/browse/MTA-7174)

### Version

* 8.1.0

### Preview

[3.3. Installing the MTA Operator](https://pkylas007.github.io/Preview/MTA/mta-7174/index.html#installing-mta-operator_installing-mta-ui)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenShift version requirement for installing the Operator to reflect the latest supported versions.
  * No installation steps or other prerequisites were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->