### PR TITLE
MTA-7174 Update required OpenShift versions in MTA Operator installation guide

### DIFF
--- a/docs/topics/mta-install/proc_creating-mta-instance.adoc
+++ b/docs/topics/mta-install/proc_creating-mta-instance.adoc
@@ -14,7 +14,7 @@ To use the {ProductShortName} UI for assessing and analyzing your applications, 
 
 * You installed the {ProductShortName} Operator on your system. For more information, see xref:installing-mta-operator_installing-mta-ui[Installing the {ProductShortName} Operator].
 * Your environment has 4 vCPUs, 8 GB RAM, and 40 GB persistent storage.
-* Your environment uses Red Hat OpenShift (cloud service or self-hosted), version 4.13–4.15.
+* Your environment uses Red Hat OpenShift (cloud service or self-hosted), version 4.21–4.22.
 * You logged in as a user with `cluster-admin` permissions.
 
 

--- a/docs/topics/mta-install/proc_installing-mta-operator.adoc
+++ b/docs/topics/mta-install/proc_installing-mta-operator.adoc
@@ -13,7 +13,7 @@ The {ProductShortName} Operator is a structural layer that manages resources dep
 .Prerequisites
 
 * Your environment has 4 vCPUs, 8 GB RAM, and 40 GB persistent storage.
-* Your environment uses Red Hat OpenShift (cloud service or self-hosted), version 4.13–4.15.
+* Your environment uses Red Hat OpenShift (cloud service or self-hosted), version 4.21–4.22.
 pass:[<!-- vale RedHat.Spelling = NO -->]
 * You created two RWO persistent volumes (PVs) used by different components.
 pass:[<!-- vale RedHat.Spelling = YES -->]
@@ -66,5 +66,3 @@ spec:
 * link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles]
 * link:{mta-URL}/installing_the_migration_toolkit_for_applications/index#persistent-volume-requirements_installing-mta-ui[Persistent volume requirements]
 * xref:custom-resource-settings_installing-mta-ui[Custom resource settings]
-
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the supported OpenShift version requirement for installing the Operator to 4.21–4.22.
  * Kept the rest of the installation guidance and verification steps unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->