### PR TITLE
MTA-7229 [DOC] Configuring repositories documentation is misleading

### DIFF
--- a/docs/topics/mta-ui/proc_configuring-git-repos.adoc
+++ b/docs/topics/mta-ui/proc_configuring-git-repos.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-git-repos_{context}"]
-= Configuring Git repositories
+= Enable insecure access to Git repositories
 
 [role="_abstract"]
-To allow {ProductFullName} to access the data required for migration tasks, configure *Git* repositories in the user interface (UI). By configuring these repositories, you enable {ProductShortName} to access your source code to identify modernization paths and required steps for your modernization efforts.
+As an administrator, you can configure {ProductFullName} to accept self-signed or internal certificates to allow an insecure connection to your internal *Git* repository.
 
 .Procedure
 

--- a/docs/topics/mta-ui/proc_configuring-maven-repo.adoc
+++ b/docs/topics/mta-ui/proc_configuring-maven-repo.adoc
@@ -4,19 +4,19 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-maven-repo_{context}"]
-= Configuring a Maven repository
+= Enable insecure access to a Maven repository
 
 [role="_abstract"]
-To give {ProductFullName} access to the data required for the migration tasks, configure *Maven* repositories in the user interface (UI). By configuring these repositories, you allow {ProductShortName} to access your source code to identify modernization paths and required steps for your modernization efforts.
+As an dministrator, you can configure {ProductFullName} to accept self-signed or internal certificates to allow an insecure connection to access your *Maven* repository.
 
-You can both configure a *Maven* repository and reduce its size in the *Repositories* view of the {ProductShortName} UI.
+You can clear the Maven cache of your local artifact repository in the *Repositories* view of the {ProductShortName} web console to save disk space.
 
-IMPORTANT: If the `rwx_supported` configuration option of the Tackle CR is set to `false`, both the *Local artifact repository* field and the *Clear repository* button are disabled. Therefore, you cannot perform the following procedure. 
+IMPORTANT: If you set the `rwx_supported` configuration field in the Tackle custom resource (CR) to `false`, {ProductShortName} disables both the *Local artifact repository* field and the *Clear repository* option. Therefore, you cannot clear Maven cache in following procedure. 
 
 .Procedure
 
 . In *Administration* view, click *Repositories* and then click *Maven*.
 . Enable the *Consume insecure artifact repositories* switch.
-. Optional: To reduce the size of the *Maven* repository, click the *Clear repository* link.
+. Optional: To reduce the size of the local *Maven* artifacts, click the *Clear repository* link.
 +
 NOTE: Depending on the size of the *Maven* repository, the size change might not be evident.

--- a/docs/topics/mta-ui/proc_configuring-subversion-repos.adoc
+++ b/docs/topics/mta-ui/proc_configuring-subversion-repos.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-subversion-repos_{context}"]
-= Configuring Subversion repositories
+= Enable insecure access to Subversion repositories
 
 [role="_abstract"]
-To allow the {ProductFullName} to access the data required for the migration tasks, configure *Subversion* repositories in the user interface (UI). By configuring these repositories, you allow {ProductShortName} to access your source code to identify modernization paths and required steps for your modernization efforts.
+As an administrator, you can configure {ProductFullName} to accept self-signed or internal certificates to allow an insecure connection to your internal *Subversion* repository.
 
 .Procedure
 


### PR DESCRIPTION
### JIRA

* [MTA-7229 [DOC] Configuring repositories documentation is misleading](https://redhat.atlassian.net/browse/MTA-7229)

### Version
* 8.1.0

### Previews

* [2.3.1. Enable insecure access to Git repositories](https://pkylas007.github.io/Preview/MTA/mta-7229-insecure-repo/index.html#configuring-git-repos_configuring-repositories)
* [2.3.2. Enable insecure access to Subversion repositories](https://pkylas007.github.io/Preview/MTA/mta-7229-insecure-repo/index.html#configuring-subversion-repos_configuring-repositories)
* [2.3.3. Enable insecure access to a Maven repository](https://pkylas007.github.io/Preview/MTA/mta-7229-insecure-repo/index.html#configuring-maven-repo_configuring-repositories)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository configuration docs to focus on enabling insecure access to internal Git, Maven, and Subversion repositories.
  * Clarified that self-signed or internal certificates can be accepted for these connections.
  * Added guidance for clearing the local Maven cache to reduce disk usage.
  * Improved the Maven procedure to reflect when repository-related options are unavailable and to include the relevant setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->