### PR TITLE
MTA-7237 - CLI installation

### DIFF
--- a/assemblies/cli-guide/assembly_analyzing-applications-mta-cli.adoc
+++ b/assemblies/cli-guide/assembly_analyzing-applications-mta-cli.adoc
@@ -27,9 +27,7 @@ Depending on your scenario, you can use the {ProductShortName} CLI to perform th
 ** Enter a series of `--analyze` commands, each against an application and each generating a separate report.
 ** Use the `--bulk` option to analyze multiple applications at once and generate a single report. Note that this feature is a Developer Preview feature only.
 
-* Run the analysis for Java applications in the containerless mode. Note that this option is set by default and is used automatically only if all requirements are met.
-+
-However, if you want to analyze applications in languages other than Java or, for example, use transformation commands, you still need to use containers.
+* Run the analysis for Java applications in containerless mode, which is the default. The CLI uses containerless mode automatically when all requirements are met. For applications that are written in languages other than Java, or when you use transformation commands, the analysis runs in container mode.
 
 ////
 [NOTE]

--- a/docs/cli-guide/master.adoc
+++ b/docs/cli-guide/master.adoc
@@ -10,6 +10,8 @@ include::topics/mta-cli/con_intro-to-the-cli.adoc[leveloffset=+1]
 
 include::topics/mta-cli/ref_supported-migration-paths.adoc[leveloffset=+1]
 
+include::assemblies/mta-install-title/assembly_installing-mta-cli.adoc[leveloffset=+1]
+
 include::assemblies/cli-guide/assembly_analyzing-applications-mta-cli.adoc[leveloffset=+1]
 
 include::assemblies/cli-guide/assembly_analyzing-nonjava-applications.adoc[leveloffset=+1]

--- a/docs/install-guide/master.adoc
+++ b/docs/install-guide/master.adoc
@@ -22,7 +22,7 @@ include::topics/mta-cli/ref_supported-migration-paths.adoc[leveloffset=+1]
 //Installing MTA
 include::assemblies/mta-install-title/assembly_installing-mta-ui.adoc[leveloffset=+1]
 
-include::assemblies/mta-install-title/assembly_installing-mta-cli.adoc[leveloffset=+1]
+include::topics/mta-install/con_installing-mta-cli-overview.adoc[leveloffset=+1]
 
 include::topics/mta-cli/ref_contributing-to-mta-development.adoc[leveloffset=+1]
 :!installing-mta-title:

--- a/docs/topics/mta-cli/proc_analyzing-multiple-apps-with-mta-cli.adoc
+++ b/docs/topics/mta-cli/proc_analyzing-multiple-apps-with-mta-cli.adoc
@@ -53,5 +53,5 @@ $ *mta-cli analyze --bulk --input _<path_to_input_C>_ --output _<path_to_output_
 [role="_additional-resources"]
 .Additional resources
 
-* link:{mta-URL}/installing_the_migration_toolkit_for_applications/index#installing-cli-zip_installing-mta-cli[Installing the CLI by using a .zip file]
+* xref:installing-cli-zip_installing-mta-cli[Installing the CLI by using a .zip file]
 * xref:mta-cli-analyze-flags_analyzing-applications-mta-cli[The mta-cli analyze command options]

--- a/docs/topics/mta-cli/proc_analyzing-single-app-with-mta-cli.adoc
+++ b/docs/topics/mta-cli/proc_analyzing-single-app-with-mta-cli.adoc
@@ -60,5 +60,5 @@ Alternatively, press *Ctrl* and click the path of the `index.html` file.
 
 [role="_additional-resources"]
 .Additional resources
-* link:{mta-URL}/installing_the_migration_toolkit_for_applications/index#installing-cli-zip_installing-mta-cli[Installing the CLI by using a .zip file]
+* xref:installing-cli-zip_installing-mta-cli[Installing the CLI by using a .zip file]
 * xref:mta-cli-analyze-flags_analyzing-applications-mta-cli[The mta-cli analyze command options]

--- a/docs/topics/mta-cli/proc_running-the-containerless-mta-cli.adoc
+++ b/docs/topics/mta-cli/proc_running-the-containerless-mta-cli.adoc
@@ -3,20 +3,20 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="running-the-containerless-mta-cli_{context}"]
-= Analyzing an application in containerless mode
+= Analyzing an application
 
 [role="_abstract"]
-To analyze applications in environments where a container engine is not available or needed, you can run the {ProductFullName} command-line interface (CLI) in containerless mode. This way, you can run assessments directly on your local machine by using the provided shell script, bypassing the need for Podman or Docker.
+By default, the {ProductFullName} command-line interface (CLI) runs in containerless mode. In this mode, the CLI uses the provided shell script to run assessments directly on your local machine, and it does not require Podman or Docker.
 
-[IMPORTANT]
+[NOTE]
 ====
-Containerless CLI is the default mode. To enable container runtime usage for the analysis of Java applications, you must set the `--run-local` flag to `false`:
+Containerless mode is the default for Java application analysis. To use a container runtime instead, set the `--run-local` parameter to `false`:
 
 ----
 --run-local=false
 ----
 
-The analysis for other applications runs in the container mode automatically.
+For applications that are written in languages other than Java, the analysis automatically runs in container mode.
 ====
 
 .Prerequisites
@@ -59,6 +59,6 @@ NOTE: The `--overwrite` option overwrites the output folder if it exists.
 [role="_additional-resources"]
 .Additional resources
 
-* link:{mta-URL}/installing_the_migration_toolkit_for_applications/index#installing-cli-zip_installing-mta-cli[Installing the CLI by using a .zip file]
+* xref:installing-cli-zip_installing-mta-cli[Installing the CLI by using a .zip file]
 * xref:mta-cli-analyze-flags_analyzing-applications-mta-cli[The mta-cli analyze command options]
 * link:https://docs.gradle.org/current/userguide/gradle_wrapper.html[Gradle Wrapper]

--- a/docs/topics/mta-cli/proc_running-the-containerless-mta-cli.adoc
+++ b/docs/topics/mta-cli/proc_running-the-containerless-mta-cli.adoc
@@ -3,7 +3,7 @@
 :_mod-docs-content-type: PROCEDURE
 
 [id="running-the-containerless-mta-cli_{context}"]
-= Analyzing an application
+= Analyzing an application in containerless mode
 
 [role="_abstract"]
 By default, the {ProductFullName} command-line interface (CLI) runs in containerless mode. In this mode, the CLI uses the provided shell script to run assessments directly on your local machine, and it does not require Podman or Docker.

--- a/docs/topics/mta-install/con_installing-mta-cli-overview.adoc
+++ b/docs/topics/mta-install/con_installing-mta-cli-overview.adoc
@@ -1,0 +1,9 @@
+:_mod-docs-content-type: CONCEPT
+
+[id="installing-mta-cli-overview_{context}"]
+= {ProductName} command-line interface installation
+
+[role="_abstract"]
+To install the {ProductFullName} command-line interface (CLI), use the instructions in the _{ProductName} CLI guide_.
+
+For more information, see link:{mta-URL}/using_the_migration_toolkit_for_applications_command-line_interface/index#installing-mta-cli_cli-guide[Installing the {ProductName} command-line interface].


### PR DESCRIPTION
---

## JIRA

* [MTA-7237](https://redhat.atlassian.net/browse/MTA-7237)

---

## PREVIEW

### CLI guide

* [3. Installing the migration toolkit for applications command-line interface](https://anarnold97.github.io/PREVIEW/MTA-7237.html#installing-mta-cli_cli-guide)
    * [3.1. Installing the CLI by using a .zip file](https://anarnold97.github.io/PREVIEW/MTA-7237.html#installing-cli-zip_installing-mta-cli)
    * [3.2. Installing the CLI on a disconnected environment](https://anarnold97.github.io/PREVIEW/MTA-7237.html#installing-mta-disconnected-environment_installing-mta-cli)
    * [3.3. Installing the CLI for use with Docker on Windows](https://anarnold97.github.io/PREVIEW/MTA-7237.html#installing-cli-for-docker_installing-mta-cli)
    
* [4.3. Analyzing an application](https://anarnold97.github.io/PREVIEW/MTA-7237.html#running-the-containerless-mta-cli_analyzing-applications-mta-cli)

### Installation Guide

* [4. migration toolkit for applications command-line interface installation](https://anarnold97.github.io/PREVIEW/MTA-7237a.html#installing-mta-cli-overview_installing-mta-title)

---
## Summary 

Moves CLI installation content into the CLI guide so that installation and usage instructions are co-located. Previously, users browsing the CLI guide had no direct path to installation instructions, which lived in a separate install guide.

### Changes:

- Adds the CLI installation assembly to the CLI guide
- Replaces the full install assembly in the install guide with a short overview that redirects users to the CLI guide
- Converts external `link:` references to installation content into internal `xref:` cross-references
- Reframes the containerless mode procedure to make clear it is the default, not a special-case option
