### PR TITLE
Preview Update 31st July

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,9 +1,11 @@
 name: PR Preview Cleanup
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
+# Write permissions are safe here — this workflow runs from the base repository
+# context and never checks out fork code (it only deletes a directory by PR number).
 permissions:
   contents: write
   pull-requests: write
@@ -18,7 +20,6 @@ jobs:
   cleanup:
     name: Remove Preview
     runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout gh-pages branch
@@ -39,11 +40,13 @@ jobs:
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git rm -rf "${PREVIEW_DIR}"
             git commit -m "chore: remove preview for PR #${PR_NUMBER}"
-
             for attempt in 1 2 3; do
               git fetch origin gh-pages
-              git rebase origin/gh-pages 2>/dev/null || { git rebase --abort; true; }
-              git push origin gh-pages && break
+              if git rebase origin/gh-pages; then
+                git push origin gh-pages && break
+              else
+                git rebase --abort
+              fi
               echo "Push attempt ${attempt} failed, retrying..."
               sleep $((attempt * 5))
             done
@@ -64,7 +67,6 @@ jobs:
 
             const marker = '<!-- pr-preview-bot -->';
 
-            // Paginate to handle PRs with more than 30 comments
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: prNumber,
             });

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -52,22 +52,36 @@ jobs:
             });
             core.setOutput('sha', pr.data.head.sha.substring(0, 7));
 
-      - name: Checkout gh-pages branch
+      - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 1
           persist-credentials: true
+
+      - name: Checkout or initialise gh-pages branch
+        run: |
+          git fetch origin gh-pages 2>/dev/null || true
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git checkout -B gh-pages origin/gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf . --quiet
+            echo "GitHub Pages for mta-documentation" > README.md
+            git add README.md
+            git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" commit -m "chore: initialise gh-pages branch"
+            git push origin gh-pages
+          fi
+
+      - name: Configure git
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy preview to gh-pages
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           COMMIT_SHA: ${{ steps.sha.outputs.sha }}
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
           PREVIEW_DIR="pr-previews/${PR_NUMBER}"
           rm -rf "${PREVIEW_DIR}"
           mkdir -p "${PREVIEW_DIR}"

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,139 @@
+name: PR Preview Deploy
+
+on:
+  workflow_run:
+    workflows: ["PR Preview"]
+    types: [completed]
+
+# Write permissions are safe here — this workflow always runs from the base
+# repository context (main branch), never from fork code.
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize all gh-pages pushes to prevent non-fast-forward failures
+# when two PRs deploy at the same time.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Download preview artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-preview-site
+          path: /tmp/pr-preview-site
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number from artifact
+        id: pr
+        run: |
+          PR_NUMBER=$(cat /tmp/pr-preview-site/.pr-number)
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          rm /tmp/pr-preview-site/.pr-number
+
+      - name: Get PR head SHA
+        id: sha
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              pull_number: ${{ steps.pr.outputs.number }},
+            });
+            core.setOutput('sha', pr.data.head.sha.substring(0, 7));
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+          persist-credentials: true
+
+      - name: Deploy preview to gh-pages
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          COMMIT_SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          PREVIEW_DIR="pr-previews/${PR_NUMBER}"
+          rm -rf "${PREVIEW_DIR}"
+          mkdir -p "${PREVIEW_DIR}"
+          cp -r /tmp/pr-preview-site/. "${PREVIEW_DIR}/"
+
+          git add "${PREVIEW_DIR}"
+          if git diff --staged --quiet; then
+            echo "No changes to deploy."
+          else
+            git commit -m "preview: PR #${PR_NUMBER} @ ${COMMIT_SHA}"
+            for attempt in 1 2 3; do
+              git fetch origin gh-pages
+              if git rebase origin/gh-pages; then
+                git push origin gh-pages && break
+              else
+                git rebase --abort
+              fi
+              echo "Push attempt ${attempt} failed, retrying..."
+              sleep $((attempt * 5))
+            done
+          fi
+
+      - name: Post or update preview comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const sha      = '${{ steps.sha.outputs.sha }}';
+            const owner    = context.repo.owner;
+            const repo     = context.repo.repo;
+
+            const previewUrl =
+              `https://${owner}.github.io/${repo}/pr-previews/${prNumber}/`;
+
+            const body = [
+              `## 📄 Documentation Preview`,
+              ``,
+              `| | |`,
+              `|---|---|`,
+              `| **Preview URL** | ${previewUrl} |`,
+              `| **Commit** | \`${sha}\` |`,
+              `| **Updated** | ${new Date().toUTCString()} |`,
+              ``,
+              `> Preview updates automatically on every push to this PR.`,
+              `> It will be removed when the PR is closed.`,
+            ].join('\n');
+
+            const marker = '<!-- pr-preview-bot -->';
+            const markedBody = marker + '\n' + body;
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo,
+                comment_id: existing.id,
+                body: markedBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: prNumber,
+                body: markedBody,
+              });
+            }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -16,29 +16,20 @@ on:
       - 'index.md'
       - '.github/workflows/pr-preview.yml'
 
+# Read-only is sufficient — this job only builds and uploads an artifact.
+# The deploy job (pr-preview-deploy.yml) runs separately with write permissions
+# via workflow_run, which works for fork PRs where this token would be read-only.
 permissions:
-  contents: write
-  pull-requests: write
-
-# Serialize all gh-pages pushes across both workflows to prevent
-# non-fast-forward failures when two PRs deploy at the same time.
-concurrency:
-  group: gh-pages-deploy
-  cancel-in-progress: false
+  contents: read
 
 jobs:
-  build-and-deploy:
-    name: Build & Deploy Preview
+  build:
+    name: Build Preview
     runs-on: ubuntu-latest
-    # Skip fork PRs — GITHUB_TOKEN is read-only for forks and the push would fail.
-    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: true
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -58,97 +49,12 @@ jobs:
             --baseurl "/mta-documentation/pr-previews/${PR_NUMBER}" \
             --destination _site
 
-      - name: Deploy preview to gh-pages
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Save PR number for deploy workflow
+        run: echo "${{ github.event.number }}" > _site/.pr-number
 
-          mkdir -p /tmp/pr-preview
-          cp -r _site/. /tmp/pr-preview/
-
-          git fetch origin gh-pages 2>/dev/null || true
-          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
-            git checkout -B gh-pages origin/gh-pages
-          else
-            git checkout --orphan gh-pages
-            git rm -rf . --quiet
-            echo "GitHub Pages for mta-documentation" > README.md
-            git add README.md
-            git commit -m "chore: initialise gh-pages branch"
-          fi
-
-          PREVIEW_DIR="pr-previews/${PR_NUMBER}"
-          rm -rf "${PREVIEW_DIR}"
-          mkdir -p "${PREVIEW_DIR}"
-          cp -r /tmp/pr-preview/. "${PREVIEW_DIR}/"
-
-          git add "${PREVIEW_DIR}"
-          if git diff --staged --quiet; then
-            echo "No changes to deploy."
-          else
-            COMMIT_SHA="${{ github.event.pull_request.head.sha }}"
-            git commit -m "preview: PR #${PR_NUMBER} @ ${COMMIT_SHA::7}"
-
-            # Retry push up to 3 times in case of a concurrent non-fast-forward
-            for attempt in 1 2 3; do
-              git fetch origin gh-pages
-              git rebase origin/gh-pages 2>/dev/null || { git rebase --abort; true; }
-              git push origin gh-pages && break
-              echo "Push attempt ${attempt} failed, retrying..."
-              sleep $((attempt * 5))
-            done
-          fi
-
-      - name: Post or update preview comment
-        uses: actions/github-script@v7
-        env:
-          PR_NUMBER: ${{ github.event.number }}
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = process.env.PR_NUMBER;
-            const sha      = context.payload.pull_request.head.sha.substring(0, 7);
-            const owner    = context.repo.owner;
-            const repo     = context.repo.repo;
-
-            const previewUrl =
-              `https://${owner}.github.io/${repo}/pr-previews/${prNumber}/`;
-
-            const body = [
-              `## 📄 Documentation Preview`,
-              ``,
-              `| | |`,
-              `|---|---|`,
-              `| **Preview URL** | ${previewUrl} |`,
-              `| **Commit** | \`${sha}\` |`,
-              `| **Updated** | ${new Date().toUTCString()} |`,
-              ``,
-              `> Preview updates automatically on every push to this PR.`,
-              `> It will be removed when the PR is closed.`,
-            ].join('\n');
-
-            const marker = '<!-- pr-preview-bot -->';
-            const markedBody = marker + '\n' + body;
-
-            // Paginate to handle PRs with more than 30 comments
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner, repo, issue_number: prNumber,
-            });
-
-            const existing = comments.find(c => c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner, repo,
-                comment_id: existing.id,
-                body: markedBody,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner, repo,
-                issue_number: prNumber,
-                body: markedBody,
-              });
-            }
+          name: pr-preview-site
+          path: _site/
+          retention-days: 1


### PR DESCRIPTION
# PR #398 — Fork-Compatible PR Preview Workflows

## Why this PR was needed

I made a fundamental mistake in PR #392 in which i worked on the logic that contributors work on branches within the `migtools/mta-documentation` repo itself. 

In practice, contributors work on **forks**. GitHub intentionally gives fork PRs a read-only `GITHUB_TOKEN` as a security measure — malicious fork code cannot write to the upstream repo. The original workflows checked for this and simply skipped, which is why every fork PR showed "job skipped."

## What PR #398 does differently

The original was a single workflow that built and deployed in one job. PR #398 splits this into three workflows using the pattern GitHub recommends for fork support.

| | PR #392 (original) | PR #398 (this PR) |
|---|---|---|
| **Build** | Single job, needed write token | `pr-preview.yml` — read-only token, builds Jekyll, uploads `_site` as an artifact |
| **Deploy** | Same job as build — failed for forks | `pr-preview-deploy.yml` — new file, triggered by `workflow_run`, always runs in the base repo context so the write token is valid even for fork PRs |
| **Cleanup** | Used `pull_request` event — skipped for forks | `pr-preview-cleanup.yml` — switched to `pull_request_target`, which always runs in the base repo context |
| **Fork PRs** | Skipped entirely | Fully supported |

## Key technical detail

The `workflow_run` and `pull_request_target` events always execute in the context of the **base repository** (main branch), not the fork — so the write token is valid and can push to `gh-pages` regardless of where the PR originated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated preview deployments for pull requests.
  - Preview links are posted or updated directly in the pull request, along with the latest commit and update time.
  - Preview builds are stored temporarily before deployment, improving separation between build and publishing steps.

- **Bug Fixes**
  - Improved preview cleanup and deployment reliability with retry handling for updates and rebased branches.
  - Failed updates are safely stopped before retrying, reducing the risk of inconsistent previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->