### PR TITLE
fix: exclude vendor directory from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,7 +39,8 @@ exclude:
   - CONTRIBUTING.adoc
   - Gemfile.lock
   - topics/
-
+  - vendor/
+  
 tag_page_layout: tag
 tag_page_dir: /tag/
 


### PR DESCRIPTION
To resolve 
```
Run bundle exec jekyll build \
Configuration file: /home/runner/work/mta-documentation/mta-documentation/_config.yml
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
            Source: /home/runner/work/mta-documentation/mta-documentation
       Destination: _site
 Incremental build: disabled. Enable with --incremental
      Generating... 
             Error: could not read file /home/runner/work/mta-documentation/mta-documentation/vendor/bundle/ruby/3.2.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb: Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/3.2.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
             ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '<%= Time.now.strftime('%Y-%m-%d %H:%M:%S %z') %>': Document 'vendor/bundle/ruby/3.2.0/gems/jekyll-3.10.0/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid date in the YAML front matter.
Error: Process completed with exit code 1.

```