### PR TITLE
Update to fix next error

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -22,15 +22,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout gh-pages branch
+      - name: Checkout repo
         uses: actions/checkout@v4
         with:
-          ref: gh-pages
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 1
           persist-credentials: true
 
+      - name: Switch to gh-pages branch
+        id: ghpages
+        run: |
+          git fetch origin gh-pages 2>/dev/null || true
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git checkout -B gh-pages origin/gh-pages
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No gh-pages branch found, nothing to clean up."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Delete preview directory
+        if: steps.ghpages.outputs.exists == 'true'
         env:
           PR_NUMBER: ${{ github.event.number }}
         run: |
@@ -55,6 +66,7 @@ jobs:
           fi
 
       - name: Update preview comment to reflect closure
+        if: steps.ghpages.outputs.exists == 'true'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
### Description

This is the cleanup workflow (pr-preview-cleanup.yml) failing because it's trying to checkout ref: gh-pages but that branch doesn't exist yet — the deploy never succeeded to create it.
The cleanup workflow needs the same treatment as the deploy workflow — check out main first, then conditionally switch to gh-pages, and if it doesn't exist, just exit early since there's nothing to clean up.

### Error

```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
Run actions/checkout@v4
Syncing repository: migtools/mta-documentation
Getting Git version info
Temporarily overriding HOME='/home/runner/work/_temp/e5246f62-1926-4a9b-b1fd-2dcc6ee5f325' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/mta-documentation/mta-documentation
Deleting the contents of '/home/runner/work/mta-documentation/mta-documentation'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/gh-pages*:refs/remotes/origin/gh-pages* +refs/tags/gh-pages*:refs/tags/gh-pages*
  The process '/usr/bin/git' failed with exit code 1
  Waiting 20 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/gh-pages*:refs/remotes/origin/gh-pages* +refs/tags/gh-pages*:refs/tags/gh-pages*
  The process '/usr/bin/git' failed with exit code 1
  Waiting 15 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +refs/heads/gh-pages*:refs/remotes/origin/gh-pages* +refs/tags/gh-pages*:refs/tags/gh-pages*
  Error: The process '/usr/bin/git' failed with exit code 1
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview cleanup reliability by safely handling cases where the preview branch is unavailable.
  * Prevented cleanup and preview-comment updates from running when no preview branch exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->