### PR TITLE
Update to fix preview deployment

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Read PR number from artifact
         id: pr
         run: |
-          PR_NUMBER=$(cat /tmp/pr-preview-site/.pr-number)
+          PR_NUMBER=$(cat /tmp/pr-preview-site/pr-number.txt)
           echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          rm /tmp/pr-preview-site/.pr-number
+          rm /tmp/pr-preview-site/pr-number.txt
 
       - name: Get PR head SHA
         id: sha

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -50,7 +50,7 @@ jobs:
             --destination _site
 
       - name: Save PR number for deploy workflow
-        run: echo "${{ github.event.number }}" > _site/.pr-number
+        run: echo "${{ github.event.number }}" > _site/pr-number.txt
 
       - name: Upload preview artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## JIRA

### Problem 
The original PR #392 added GitHub Actions workflows to automatically build and deploy documentation previews for pull requests. However, all contributors work on forks of migtools/mta-documentation. GitHub intentionally restricts fork PRs to a read-only GITHUB_TOKEN, so the original single-workflow approach was silently skipping all fork PRs with "job skipped."

### Solution 
Split the original single workflow into three separate workflows using the GitHub-recommended pattern for fork-safe deployments:

* pr-preview.yml (build only): Triggers on pull_request events for changes to docs, assemblies, topics, and config files
Builds the Jekyll site with a PR-specific base URL. Uploads the built site as a GitHub artifact. Uses read-only token — safe for forks

* pr-preview-deploy.yml (new): Triggers via workflow_run after the build completes. Downloads the artifact, auto-creates gh-pages branch if it doesn't exist, deploys the preview, and posts a comment on the PR with the preview URL
pr-preview-cleanup.yml (updated)

Removes the preview directory and updates the PR comment when a PR is closed

## Error in PR preview deploy

```
41s
0s
Run PR_NUMBER=$(cat /tmp/pr-preview-site/.pr-number)
cat: /tmp/pr-preview-site/.pr-number: No such file or directory
Error: Process completed with exit code 1.
```