### PR TITLE
Updating PR preview deployment and _config.yml

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -84,12 +84,23 @@ jobs:
           COMMIT_SHA: ${{ steps.sha.outputs.sha }}
         run: |
           touch .nojekyll
+          # Write a minimal _config.yml to the gh-pages root so Jekyll only
+          # passes through the pr-previews/ directory without reprocessing it.
+          cat > _config.yml << 'EOF'
+include:
+  - pr-previews/
+exclude:
+  - "*"
+EOF
           PREVIEW_DIR="pr-previews/${PR_NUMBER}"
           rm -rf "${PREVIEW_DIR}"
           mkdir -p "${PREVIEW_DIR}"
           cp -r /tmp/pr-preview-site/. "${PREVIEW_DIR}/"
+          # Remove _config.yml from the preview dir so GitHub Pages does not
+          # treat gh-pages as a Jekyll source and re-run Jekyll on it.
+          rm -f "${PREVIEW_DIR}/_config.yml"
 
-          git add .nojekyll "${PREVIEW_DIR}"
+          git add .nojekyll _config.yml "${PREVIEW_DIR}"
           if git diff --staged --quiet; then
             echo "No changes to deploy."
           else

--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ show_downloads: false
 title: Migration Toolkit for Applications Documentation
 permalink: pretty
 repository: migtools/mta-documentation
-baseurl: /mta-documentation
+baseurl: /
 url: https://migtools.github.io
 repository_url: https://github.com/migtools/mta-documentation
 


### PR DESCRIPTION
_config.yml (main repo)

* Updated title, repository, url, and repository_url from stale windup values to correct MTA/migtools values

* Added docs/topics/ to the exclude list to prevent Jekyll from processing the large image directory during builds

* baseurl kept as `/`

### .github/workflows/pr-preview-deploy.yml

* Deploy step now writes a minimal _config.yml to the root of the gh-pages branch on every deploy, telling Jekyll to only pass through pr-previews/ and exclude everything else — this prevents GitHub Pages from running a full Jekyll rebuild on the 8+ GB branch content which was causing deployments to fail




