### PR TITLE
MTA CLI guide appendix single link fix

### DIFF
--- a/assemblies/cli-guide/assembly_reference-material.adoc
+++ b/assemblies/cli-guide/assembly_reference-material.adoc
@@ -31,7 +31,7 @@ include::assembly_rule-story-points.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources
-* link:{mta-URL}/html-single/configuring_and_using_rules_for_an_mta_analysis/index[Configuring and using rules for an MTA analysis]
+* link:{mta-URL}/configuring_and_using_rules_for_an_mta_analysis/index[Configuring and using rules for an MTA analysis]
 
 ifdef::parent-context-of-reference-material[:context: {parent-context-of-reference-material}]
 ifndef::parent-context-of-reference-material[:!context:]


### PR DESCRIPTION
### Description

Fixed a single link not found error in the CLI guide Appendix section.

### Version

* 8.2.0

### Preview

A.3. Additional resources
[Configuring and using rules for an MTA analysis](https://docs.redhat.com/en/documentation/migration_toolkit_for_applications/8.2/html-single/configuring_and_using_rules_for_an_mta_analysis/index)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the additional resources link to use the new MTA URL path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->