### PR TITLE
MTA Rules guide removed an additional resources link

### DIFF
--- a/docs/topics/rules-development/create-first-yaml-rule.adoc
+++ b/docs/topics/rules-development/create-first-yaml-rule.adoc
@@ -165,9 +165,6 @@ INFO[0066] Static report created. Access it at this URL:  URL="file:/home/<USER>
 . Verify that the issue with the title `Find class loading element in JBoss XML file` is present in the table.
 . Click the *jboss-web.xml* link to open the affected file.
 
-[role="_additional-resources"]
-.Additional resources
-* link:{ProductDocUserGuideURL}/index#installing_and_running_the_cli[Installing and running the CLI]
 
 
 


### PR DESCRIPTION
### Description

Removed the additional resources link to the CLI analysis procedure in the topic to create a Java rule.

### Version

* 8.2.0

### Preview

* [7.1. Creating a YAML rule - Removed the additional resources link to CLI analysis](https://pkylas007.github.io/Preview/MTA/mta-rules-link-remove/index.html#create-first-yaml-rule_creating-rule) 