### PR TITLE
[WIP] [MTA 8.2.1] RNs and attributes for MTA 8.2.1

### DIFF
--- a/assemblies/release-notes/assembly_mta-8-0.adoc
+++ b/assemblies/release-notes/assembly_mta-8-0.adoc
@@ -15,7 +15,7 @@ endif::[]
 :context: mta-8-0
 
 [role="_abstract"]
-Review new features, enhancements, and fixed issues in {ProductFullName} 8.0.
+This Release Notes section provides high-level coverage of the improvements and additions that have been implemented in {ProductFullName} 8.0.
 
 include::assembly_mta-8-0-1.adoc[leveloffset=+1]
 

--- a/assemblies/release-notes/assembly_mta-8-2-0.adoc
+++ b/assemblies/release-notes/assembly_mta-8-2-0.adoc
@@ -10,7 +10,7 @@ endif::[]
 ifdef::context[]
 [id="mta-8-2-0_{context}"]
 endif::[]
-= {ProductFirstRef} 8.2
+= {ProductShortName} 8.2.0
 
 :context: mta-8-2-0
 

--- a/assemblies/release-notes/assembly_mta-8-2-1.adoc
+++ b/assemblies/release-notes/assembly_mta-8-2-1.adoc
@@ -1,0 +1,24 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-08-11
+:_mod-docs-content-type: ASSEMBLY
+
+ifdef::context[:parent-context-of-mta-8-2-1: {context}]
+
+ifndef::context[]
+[id="mta-8-2-1"]
+endif::[]
+ifdef::context[]
+[id="mta-8-2-1_{context}"]
+endif::[]
+= {ProductShortName} 8.2.1
+
+:context: mta-8-2-1
+
+[role="_abstract"]
+Review new features, enhancements, deprecated features, fixed issues, and known issues in {ProductFullName} 8.2.1.
+
+include::topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc[leveloffset=+1]
+
+ifdef::parent-context-of-mta-8-2-1[:context: {parent-context-of-mta-8-2-1}]
+ifndef::parent-context-of-mta-8-2-1[:!context:]
+

--- a/assemblies/release-notes/assembly_mta-8-2.adoc
+++ b/assemblies/release-notes/assembly_mta-8-2.adoc
@@ -1,0 +1,26 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-08-11
+:_mod-docs-content-type: ASSEMBLY
+
+ifdef::context[:parent-context-of-mta-8-2: {context}]
+
+ifndef::context[]
+[id="mta-8-2"]
+endif::[]
+ifdef::context[]
+[id="mta-8-2_{context}"]
+endif::[]
+= {ProductFirstRef} 8.2
+
+:context: mta-8-2
+
+[role="_abstract"]
+This Release Notes section provides high-level coverage of the improvements and additions that have been implemented in {ProductFullName} 8.2.
+
+include::assembly_mta-8-2-1.adoc[leveloffset=+1]
+
+include::assembly_mta-8-2-0.adoc[leveloffset=+1]
+
+ifdef::parent-context-of-mta-8-2[:context: {parent-context-of-mta-8-2}]
+ifndef::parent-context-of-mta-8-2[:!context:]
+

--- a/docs/release-notes/master.adoc
+++ b/docs/release-notes/master.adoc
@@ -10,10 +10,10 @@ include::topics/templates/document-attributes.adoc[]
 :_mod-docs-content-type: ASSEMBLY
 = Release Notes
 
-include::assemblies/release-notes/assembly_mta-8-2-0.adoc[leveloffset=+1]
+include::assemblies/release-notes/assembly_mta-8-2.adoc[leveloffset=+1]
 
 include::assemblies/release-notes/assembly_mta-8-1.adoc[leveloffset=+1]
 
 include::assemblies/release-notes/assembly_mta-8-0.adoc[leveloffset=+1]
 
-:!release-notes:
+:!release-notes: 

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc
@@ -8,8 +8,8 @@
 [role="_abstract"]
 Review issues that have been fixed in {ProductFullName} version 8.2.1.
 
-`mta-ops transform` supports the `--overwrite` flag::
-Before this update, the `mta-ops transform` command did not support the `--overwrite` flag. If a custom stage directory already existed, the pipeline stopped. As a consequence, you could not automatically overwrite existing custom modifications during a pipeline re-run. With this release, the command was updated to accept the `--overwrite` flag. As a result, the command automatically overwrites existing custom modifications during a re-run when you specify the flag. You no longer need to manually delete the existing transform or custom stage directory before a re-run.
+`mta-ops transform` uses the `--overwrite` flag for consistent behavior::
+Before this update, the `mta-ops transform` command used a `--force` flag. This flag functioned only with the `--instructions-file` option. Without an instructions file, plugin stage directories were silently overwritten. Additionally, custom stage directories blocked the pipeline with no way to proceed. With this release, the `--force` flag was replaced with `--overwrite`. This change aligns the `transform` command with other `mta-ops` subcommands. As a result, all stage directories require the `--overwrite` flag to replace existing content. This gives you explicit control over data replacement during a pipeline re-run.
 +
 link:https://redhat.atlassian.net/browse/MTA-7234[MTA-7234]
 

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc
@@ -15,6 +15,6 @@ link:https://redhat.atlassian.net/browse/MTA-7234[MTA-7234]
 
 
 The {ProductShortName} Operator delegates authentication to the external Keycloak instance after an upgrade::
-Before this update, you could set the `idp_primary` parameter to `true` in the {ProductFullName} Operator custom resource (CR). However, during an upgrade, the Operator did not delegate authentication to the external Keycloak instance. As a consequence, the system continued to use the internal Keycloak instance. This caused incorrect authentication when you attempted to log in. With this release, the Operator recognizes the `idp_primary` parameter during an upgrade. As a result, the system delegates authentication to the external Keycloak instance when the parameter is `true`.
+Before this update, you could set the `idp_primary` parameter to `true` in the {ProductShortName} Operator custom resource (CR). However, during an upgrade, the Operator did not delegate authentication to the external Keycloak instance. As a consequence, the system continued to use the internal Keycloak instance. This caused incorrect authentication when you attempted to log in. With this release, the Operator processes the `idp_primary` parameter during an upgrade. As a result, the system delegates authentication to the external Keycloak instance when the parameter is `true`.
 +
 link:https://redhat.atlassian.net/browse/MTA-7496[MTA-7496]

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc
@@ -12,3 +12,9 @@ Review issues that have been fixed in {ProductFullName} version 8.2.1.
 Before this update, the `mta-ops transform` command did not support the `--overwrite` flag. If a custom stage directory already existed, the pipeline stopped. As a consequence, you could not automatically overwrite existing custom modifications during a pipeline re-run. With this release, the command was updated to accept the `--overwrite` flag. As a result, the command automatically overwrites existing custom modifications during a re-run when you specify the flag. You no longer need to manually delete the existing transform or custom stage directory before a re-run.
 +
 link:https://redhat.atlassian.net/browse/MTA-7234[MTA-7234]
+
+
+The {ProductShortName} Operator delegates authentication to the external Keycloak instance after an upgrade::
+Before this update, you could set the `idp_primary` parameter to `true` in the {ProductFullName} Operator custom resource (CR). However, during an upgrade, the Operator did not delegate authentication to the external Keycloak instance. As a consequence, the system continued to use the internal Keycloak instance. This caused incorrect authentication when you attempted to log in. With this release, the Operator recognizes the `idp_primary` parameter during an upgrade. As a result, the system delegates authentication to the external Keycloak instance when the parameter is `true`.
++
+link:https://redhat.atlassian.net/browse/MTA-7496[MTA-7496]

--- a/docs/topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc
+++ b/docs/topics/release-notes-topics/ref_fixed-issues-8-2-1.adoc
@@ -1,0 +1,14 @@
+:_newdoc-version: 2.18.7
+:_template-generated: 2026-08-11
+:_mod-docs-content-type: REFERENCE
+
+[id="fixed-issues-8-2-1_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+Review issues that have been fixed in {ProductFullName} version 8.2.1.
+
+`mta-ops transform` supports the `--overwrite` flag::
+Before this update, the `mta-ops transform` command did not support the `--overwrite` flag. If a custom stage directory already existed, the pipeline stopped. As a consequence, you could not automatically overwrite existing custom modifications during a pipeline re-run. With this release, the command was updated to accept the `--overwrite` flag. As a result, the command automatically overwrites existing custom modifications during a re-run when you specify the flag. You no longer need to manually delete the existing transform or custom stage directory before a re-run.
++
+link:https://redhat.atlassian.net/browse/MTA-7234[MTA-7234]

--- a/docs/topics/templates/document-attributes.adoc
+++ b/docs/topics/templates/document-attributes.adoc
@@ -27,14 +27,14 @@ ifdef::mta[]
 :WebNameTitle: User Interface
 :WebNameURL: user_interface_guide
 :WebConsoleBookName: {WebNameTitle} Guide
-:ProductVersion: 8.2.0
+:ProductVersion: 8.2.1
 :PluginName: MTA plugin
 :mta-dl-full: Red Hat Developer Lightspeed for migration toolkit for applications
 :mta-dl-plugin: Red Hat Developer Lightspeed for MTA
 :mta-URL: https://docs.redhat.com/en/documentation/migration_toolkit_for_applications/{DocInfoProductNumber}/html-single
 
-:ProductDistributionVersion: 8.2.0.GA-redhat
-:ProductDistribution: mta-8.2.0.GA-cli-offline.zip
+:ProductDistributionVersion: 8.2.1.GA-redhat
+:ProductDistribution: mta-8.2.1.GA-cli-offline.zip
 :DevDownloadPageURL: https://developers.redhat.com/products/mta/download
 :JiraWindupURL: https://issues.redhat.com/projects/MTA/issues
 // OpenShift


### PR DESCRIPTION
### Trackers

- Release notes: [MTA-7374](https://redhat.atlassian.net/browse/MTA-7374)
- Attributes: [MTA-7373](https://redhat.atlassian.net/browse/MTA-7373)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added release notes for MTA 8.2 and 8.2.1.
  - Documented support for `mta-ops transform --overwrite`.
  - Documented post-upgrade delegation to an external Keycloak when `idp_primary` is enabled.

- **Documentation**
  - Updated release-note titles, abstracts, and version references.
  - Updated product and CLI archive versions from 8.2.0 to 8.2.1.
  - Improved release-note organization and version-specific coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->